### PR TITLE
Fix addon/register to detect environment name correctly

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -112,7 +112,7 @@ curl)
   ;;
 
 register)
-  env=${1:$GENESIS_ENVIRONMENT}
+  env=${1:-$GENESIS_ENVIRONMENT}
   cf_api=$(exodus $env/cf api_url)
   cf_user=$(exodus $env/cf admin_username)
   cf_pass=$(exodus $env/cf admin_password)


### PR DESCRIPTION
The script had an empty environment name previously causing the cf auth commands to fail.