### PR TITLE
Add external-bosh support

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -103,6 +103,26 @@ new data services instances on behalf of end users.
   - `vsphere_clusters` - A YAML list of vSphere cluster names
     where Blacksmith will deploy service VMs.
 
+
+- `external-bosh` (IaaS substitute) - Deploy the on-demand services to an
+  existing bosh director.  You will need to provide all of the information
+  Blacksmith needs to contact bosh director for deployments orchestration
+  purposes.
+
+  Activating this feature also activates the following parameters:
+
+  - `external_bosh.address` - The IP address of the external BOSH director to
+    deploy to.
+
+  - `external_bosh.cacert` - The CA certificate of the external BOSH director.
+
+  - `external_bosh.username` - The username to authenticate with the external
+    bosh director. This user must have permissions to manage its deployments,
+    upload releases and stemcells.
+
+  - `external_bosh.password` - The password for the above user to authenticate
+    against the external bosh director.
+
 - `postgresql` (Blacksmit Forge) - Enables the Blacksmith Service
   Broker to deploy PostgreSQL database services.
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Improvements
+- Adds the `external-bosh` feature to allow deploying on-demand services to an
+  existing bosh director.

--- a/hooks/addon
+++ b/hooks/addon
@@ -9,10 +9,10 @@ export BLACKSMITH_URL=http://$ip:$port
 export BLACKSMITH_USERNAME=blacksmith
 export BLACKSMITH_PASSWORD=$(safe read $vault/broker:password)
 
-export BOSH_ENVIRONMENT=https://$(lookup params.ip):25555
-export BOSH_CA_CERT=$(safe read $vault/tls/ca:certificate)
-export BOSH_CLIENT="admin"
-export BOSH_CLIENT_SECRET="$(safe read ${vault}/users/admin:password)"
+export BOSH_ENVIRONMENT=$(exodus bosh_address)
+export BOSH_CA_CERT=$(exodus bosh_cacert)
+export BOSH_CLIENT=$(exodus bosh_username)
+export BOSH_CLIENT_SECRET="$(exodus bosh_password)"
 
 list() {
   echo "The following addons are defined:"
@@ -69,8 +69,8 @@ is_logged_in() {
 login() {
   bosh logout >/dev/null 2>&1
 
-  echo "Logging you in as user 'admin'..."
-  printf "%s\n%s\n" admin "$(safe read $vault/users/admin:password)" | \
+  echo "Logging you in as user '${BOSH_CLIENT}'..."
+  printf "%s\n%s\n" "${BOSH_CLIENT}" "${BOSH_CLIENT_SECRET}" | \
     BOSH_CLIENT="" BOSH_CLIENT_SECRET="" bosh login
 }
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -12,12 +12,12 @@ validate_features aws azure google openstack vsphere external-bosh \
 merge=( manifests/blacksmith/blacksmith.yml )
 
 iaas=0
-if ! want_feature "external-bosh" ; then
-  merge+=( manifests/blacksmith/bosh.yml )
-else
+if want_feature "external-bosh" ; then
   merge+=( manifests/blacksmith/external-bosh.yml )
   # No IaaS Specification needed with external bosh
   iaas=$(( iaas + 1 ))
+else
+  merge+=( manifests/blacksmith/bosh.yml )
 fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -3,16 +3,23 @@ set -eu
 
 declare -a merge
 
-validate_features aws azure google openstack vsphere \
+validate_features aws azure google openstack vsphere external-bosh \
                   rabbitmq redis postgresql mariadb kubernetes
 
 #
 # We always start out with the skeleton of a BOSH deployment,
 # and add-in a local UAA and a Credhub
-merge=( manifests/blacksmith/blacksmith.yml
-        manifests/blacksmith/bosh.yml )
+merge=( manifests/blacksmith/blacksmith.yml )
 
 iaas=0
+if ! want_feature "external-bosh" ; then
+  merge+=( manifests/blacksmith/bosh.yml )
+else
+  merge+=( manifests/blacksmith/external-bosh.yml )
+  # No IaaS Specification needed with external bosh
+  iaas=$(( iaas + 1 ))
+fi
+
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
   # IaaS selector feature flags

--- a/kit.yml
+++ b/kit.yml
@@ -52,4 +52,3 @@ credentials:
     users/blacksmith:   {password: random 64}
 
     registry:           {password: random 64}
-

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -14,6 +14,10 @@ exodus:
   broker_url: (( concat "http://" params.ip ":" params.blacksmith_port || 3000 ))
   broker_username: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.broker.username ))
   broker_password: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.broker.password ))
+  bosh_username: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.bosh.username ))
+  bosh_password: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.bosh.password ))
+  bosh_address: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.bosh.address ))
+  bosh_cacert: (( vault meta.vault "/tls/ca:certificate" ))
 
 instance_groups:
   - name:      blacksmith

--- a/manifests/blacksmith/external-bosh.yml
+++ b/manifests/blacksmith/external-bosh.yml
@@ -1,0 +1,30 @@
+---
+meta:
+  default_bosh_exodus_path:     (( concat $GENESIS_ENVIRONMENT "/bosh" ))
+  bosh_exodus_path:             (( grab params.bosh_exodus_path || meta.default_bosh_exodus_path ))
+  bosh_exodus_src:              (( concat $GENESIS_EXODUS_MOUNT meta.bosh_exodus_path ":" ))
+  
+  external_bosh_username: (( vault meta.bosh_exodus_src "blacksmith_user" ))
+  external_bosh_password: (( vault meta.bosh_exodus_src "blacksmith_password" ))
+  external_bosh_address: (( vault meta.bosh_exodus_src "url" ))
+  external_bosh_cacert: (( vault meta.bosh_exodus_src "ca_cert" ))
+
+exodus:
+  bosh_cacert: (( grab params.external_bosh.cacert || meta.external_bosh_cacert ))
+
+params:
+  cloud_config: []
+
+instance_groups:
+  - name: blacksmith
+    jobs:
+      - release: blacksmith
+        name: blacksmith
+        properties:
+          bosh:
+            username: (( grab params.external_bosh.username || meta.external_bosh_username ))
+            password: (( grab params.external_bosh.password || meta.external_bosh_password ))
+            address:  (( grab params.external_bosh.address || meta.external_bosh_address))
+            stemcells: []
+            releases: []
+            cloud-config: []


### PR DESCRIPTION
Allows blacksmith to use an existing bosh director to deploy services
instead of creating its own. This will use the env bosh director by default
via exodus data, however this can be changed via params if desired.