### PR TITLE
Blacksmith tls support feature

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -42,6 +42,14 @@ new data services instances on behalf of end users.
 - `blacksmith_port` - The TCP port that Blacksmith will bind to
   This defaults to `3000`.
 
+- `blacksmith_tls_port` - The TCP port that Blacksmith will bind to for tls traffic
+  This defaults to `443`.
+
+- `blacksmith_tls_certificate` - The certificate blacksmith should present for
+  https traffic on the webui and api.
+
+- `blacksmith_tls_key` - The corresponding key for the above certificate.
+
 - `blacksmith_env` - An identifying string that will be used to
   differentiate Blacksmith brokers in their management UIs.
   Defaults to empty, but you probably want to set this.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,9 @@
 # Improvements
 - Adds the `external-bosh` feature to allow deploying on-demand services to an
   existing bosh director.
+- Adds the `broker-tls` feature which configures blacksmith to listen on https
+  for the WebUI and the broker api
+
+# Software Updates
+
+- Bumped blacksmith-boshrelease to 1.1.1

--- a/hooks/addon
+++ b/hooks/addon
@@ -7,9 +7,11 @@ ip=$(lookup params.ip)
 if want_feature "broker-tls"; then
   port=$(lookup params.blacksmith_tls_port 443)
   export BLACKSMITH_URL=https://$ip:$port
+  scheme=https
 else
   port=$(lookup params.blacksmith_port 3000)
   export BLACKSMITH_URL=http://$ip:$port
+  scheme=http
 fi
 
 export BLACKSMITH_USERNAME=blacksmith
@@ -91,7 +93,7 @@ visit)
     echo "The 'visit' addon script only works on macOS, currently."
     exit 1
   fi
-  open "http://$BLACKSMITH_USERNAME:$BLACKSMITH_PASSWORD@$ip:$port"
+  open "$scheme://$BLACKSMITH_USERNAME:$BLACKSMITH_PASSWORD@$ip:$port"
   ;;
 
 bosh)

--- a/hooks/addon
+++ b/hooks/addon
@@ -4,8 +4,14 @@ vault="secret/$GENESIS_VAULT_PREFIX"
 alias="$GENESIS_ENVIRONMENT-blacksmith"
 
 ip=$(lookup params.ip)
-port=$(lookup params.port 3000)
-export BLACKSMITH_URL=http://$ip:$port
+if want_feature "broker-tls"; then
+  port=$(lookup params.blacksmith_tls_port 443)
+  export BLACKSMITH_URL=https://$ip:$port
+else
+  port=$(lookup params.blacksmith_port 3000)
+  export BLACKSMITH_URL=http://$ip:$port
+fi
+
 export BLACKSMITH_USERNAME=blacksmith
 export BLACKSMITH_PASSWORD=$(safe read $vault/broker:password)
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -12,7 +12,7 @@ validate_features aws azure google openstack vsphere external-bosh \
 merge=( manifests/blacksmith/blacksmith.yml )
 
 iaas=0
-if want_feature "external-bosh" ; then
+if want_feature "external-bosh"; then
   merge+=( manifests/blacksmith/external-bosh.yml )
   # No IaaS Specification needed with external bosh
   iaas=$(( iaas + 1 ))
@@ -20,7 +20,7 @@ else
   merge+=( manifests/blacksmith/bosh.yml )
 fi
 
-if want_feature "broker-tls" ; then
+if want_feature "broker-tls"; then
   merge+=( manifests/blacksmith/broker-tls.yml )
 fi
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -4,7 +4,7 @@ set -eu
 declare -a merge
 
 validate_features aws azure google openstack vsphere external-bosh \
-                  rabbitmq redis postgresql mariadb kubernetes
+                  rabbitmq redis postgresql mariadb kubernetes broker-tls
 
 #
 # We always start out with the skeleton of a BOSH deployment,
@@ -18,6 +18,10 @@ if want_feature "external-bosh" ; then
   iaas=$(( iaas + 1 ))
 else
   merge+=( manifests/blacksmith/bosh.yml )
+fi
+
+if want_feature "broker-tls" ; then
+  merge+=( manifests/blacksmith/broker-tls.yml )
 fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do

--- a/hooks/info
+++ b/hooks/info
@@ -3,15 +3,24 @@ set -eu
 vault="secret/$GENESIS_VAULT_PREFIX"
 
 ip=$(lookup params.ip)
-port=$(lookup params.port 3000)
-export BLACKSMITH_URL=http://$ip:$port
+ip=$(lookup params.ip)
+if want_feature "broker-tls"; then
+  port=$(lookup params.blacksmith_tls_port 443)
+  scheme=https
+  export BLACKSMITH_URL=https://$ip:$port
+  export BLACKSMITH_SKIP_VERIFY=true
+else
+  port=$(lookup params.blacksmith_port 3000)
+  scheme=http
+  export BLACKSMITH_URL=http://$ip:$port
+fi
 export BLACKSMITH_USERNAME=blacksmith
 export BLACKSMITH_PASSWORD=$(safe read $vault/broker:password)
 
-export BOSH_ENVIRONMENT=https://$(lookup params.ip):25555
-export BOSH_CA_CERT=$(safe read $vault/tls/ca:certificate)
-export BOSH_CLIENT=admin
-export BOSH_CLIENT_SECRET=$(safe read $vault/users/admin:password)
+export BOSH_ENVIRONMENT=$(exodus bosh_address)
+export BOSH_CA_CERT=$(exodus bosh_cacert)
+export BOSH_CLIENT=$(exodus bosh_username)
+export BOSH_CLIENT_SECRET="$(exodus bosh_password)"
 
 
 describe "ca certificate"
@@ -31,7 +40,7 @@ describe "  password: #G{$BOSH_CLIENT_SECRET}"
 describe "  web url:   #C{$BLACKSMITH_URL}"
 describe "  username:  #M{$BLACKSMITH_USERNAME}"
 describe "  password:  #G{$BLACKSMITH_PASSWORD}"
-describe "  clickable: #B{http://$BLACKSMITH_USERNAME:$BLACKSMITH_PASSWORD@$ip:$port}"
+describe "  clickable: #B{$scheme://$BLACKSMITH_USERNAME:$BLACKSMITH_PASSWORD@$ip:$port}"
     echo
     echo
     echo "blacksmith catalog"

--- a/hooks/new
+++ b/hooks/new
@@ -11,7 +11,8 @@ prompt_for iaas select \
 	-o '[aws]       Amazon Web Services'   \
 	-o '[azure]     Microsoft Azure'       \
 	-o '[google]    Google Cloud Platform' \
-	-o '[openstack] OpenStack'
+	-o '[openstack] OpenStack'             \
+	-o '[external-bosh]  Deploy to an External Bosh Director'
 
 case $iaas in
 aws)
@@ -124,6 +125,11 @@ openstack)
 	;;
 esac
 
+# Broker TLS
+echo "The Blacksmith broker can be configured to use TLS by default."
+prompt_for broker_tls boolean \
+	'Would you like to access the broker api and WebUI using https?'
+
 
 # Forges
 echo "Blacksmith Forges allow you to deploy different"
@@ -175,6 +181,10 @@ echo "    - $iaas"
 for forge in ${forges[@]}; do
   echo "    - $forge"
 done
+
+if [[ $broker_tls == 'true' ]]; then
+	echo "    - broker-tls"
+fi
 
 echo
 echo "params:"

--- a/kit.yml
+++ b/kit.yml
@@ -12,7 +12,7 @@ genesis_version_min: 2.6.0
 certificates:
   base:
     tls:
-      ca: {valid_for: 1y}
+      ca: {valid_for: 10y}
       director:
         valid_for: 1y
         names:
@@ -23,7 +23,7 @@ certificates:
           - ${params.ip}
 
     tls/nats:
-      ca: {valid_for: 1y}
+      ca: {valid_for: 10y}
       server:
         valid_for: 1y
         names:
@@ -40,7 +40,7 @@ certificates:
 
   broker-tls:
     broker:
-      ca: {valid_for: 1y}
+      ca: {valid_for: 10y}
       server:
           valid_for: 1y
           names:

--- a/kit.yml
+++ b/kit.yml
@@ -38,6 +38,15 @@ certificates:
         names:
           - default.hm.bosh-internal
 
+  broker-tls:
+    broker:
+      ca: {valid_for: 1y}
+      server:
+          valid_for: 1y
+          names:
+            - ${params.ip}
+
+
 credentials:
   base:
     broker:             {password: random 64}

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -51,11 +51,10 @@ instance_groups:
             cloud-config: (( grab params.cloud_config ))
 
 releases:
-  - name:    blacksmith
-    version: latest
-    #version: 1.1.0
-    #url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.1.0/blacksmith-1.1.0.tgz
-    #sha1:    012668d7ebb68740e89640105931f3f18b00727b
+- name:    blacksmith
+  version: 1.1.1
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.1.1/blacksmith-1.1.1.tgz
+  sha1:    a32e51cef4cbb94c5890f29388852ddea081b283
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -52,9 +52,10 @@ instance_groups:
 
 releases:
   - name:    blacksmith
-    version: 1.1.0
-    url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.1.0/blacksmith-1.1.0.tgz
-    sha1:    012668d7ebb68740e89640105931f3f18b00727b
+    version: latest
+    #version: 1.1.0
+    #url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.1.0/blacksmith-1.1.0.tgz
+    #sha1:    012668d7ebb68740e89640105931f3f18b00727b
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/broker-tls.yml
+++ b/manifests/blacksmith/broker-tls.yml
@@ -1,0 +1,16 @@
+meta:
+  blacksmith_tls_certificate: (( vault meta.vault "/broker/server:certificate" ))
+  blacksmith_tls_key: (( vault meta.vault "/broker/server:key" ))
+
+instance_groups:
+  - name: blacksmith
+    jobs:
+    - name: blacksmith
+      properties:
+        broker:
+          port: (( grab params.blacksmith_port || 80 ))
+          tls:
+            enabled: true
+            port: (( grab params.blacksmith_tls_port || 443 ))
+            key: (( grab meta.blacksmith_tls_key || params.blacksmith_tls_key ))
+            certificate: (( grab meta.blacksmith_tls_certificate || params.blacksmith_tls_certificate )) 

--- a/manifests/blacksmith/broker-tls.yml
+++ b/manifests/blacksmith/broker-tls.yml
@@ -12,5 +12,5 @@ instance_groups:
           tls:
             enabled: true
             port: (( grab params.blacksmith_tls_port || 443 ))
-            key: (( grab meta.blacksmith_tls_key || params.blacksmith_tls_key ))
-            certificate: (( grab meta.blacksmith_tls_certificate || params.blacksmith_tls_certificate )) 
+            key: (( grab params.blacksmith_tls_key || meta.blacksmith_tls_key ))
+            certificate: (( grab params.blacksmith_tls_certificate || meta.blacksmith_tls_certificate ))


### PR DESCRIPTION
- Adds the `broker-tls` feature which configures blacksmith to listen on https
  for the WebUI and the broker api
- When enabled it will listen on `params.blacksmith_tls_port` (default 443) for https and redirect traffic from `params.blacksmith_port` (default 80 when enabled)