### PR TITLE
Support CF kits 1.x and 2.x

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -121,7 +121,12 @@ curl)
 
 register)
   env=${1:-$GENESIS_ENVIRONMENT}
-  cf_api=$(exodus "$env/cf" api_url)
+  cf_version=$(exodus "$env/cf" kit_version)
+  if new_enough "${cf_version}" "2.0.0-rc1" ; then
+    cf_api="https://$(exodus "$env/cf" api_domain)"
+  else
+    cf_api=$(exodus "$env/cf" api_url)
+  fi
   cf_user=$(exodus "$env/cf" admin_username)
   cf_pass=$(exodus "$env/cf" admin_password)
 


### PR DESCRIPTION
CF kit 2.x abandoned exporting `api_url` into exodus data. This breaks the `register` addon for this kit. The solution is to properly detect which version of the CF kit was used and then get the API URL.