### PR TITLE
Update all components to Bionic

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -19,12 +19,10 @@ new data services instances on behalf of end users.
 
 - `stemcell_os` - The operating system you want to deploy the
   Blacksmith service broker itself on.  This defaults to
-  `ubuntu-xenial`.
+  `ubuntu-bionic`.
 
 - `stemcell_version` - The version of the stemcell to deploy.
-  Defaults to `97.latest`, which is usually what you want, since
-  this kit uses precompiled BOSH director releases that only work
-  on the 97.x ubuntu-xenial series.
+  Defaults to `1.latest`
 
 - `vm_type` - The name of the `vm_type` (per cloud-config) that
   will be used to deploy the blacksmith broker VM.  Defaults to

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,12 @@
+# Software Updates:
+
+Updated all Forges and Embedded Blacksmith to use Bionic Stemcells
+* Updated MariaDB Forge to 10.4.22
+* Updated PostgreSQL forge to 9.5.25
+* Upadted Redis Forge to 5.0.14 and 6.2.6
+* Updated RabbitMQ forge to 3.7.28
+* Bump all default stemcells to Bionic 1.36
+
+# Deprecation Notice
+
+* Future releases of embedded BOSH will drop vCenter 6.0 support

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -3,7 +3,7 @@
 Updated all Forges and Embedded Blacksmith to use Bionic Stemcells
 * Updated MariaDB Forge to 10.4.22
 * Updated PostgreSQL forge to 9.5.25
-* Upadted Redis Forge to 5.0.14 and 6.2.6
+* Updated Redis Forge to 5.0.14 and 6.2.6
 * Updated RabbitMQ forge to 3.7.28
 * Bump all default stemcells to Bionic 1.36
 

--- a/kit.yml
+++ b/kit.yml
@@ -1,6 +1,6 @@
 ---
 name:    blacksmith
-version: 0.11.6
+version: 0.12.0
 author:  James Hunt <james@niftylogic.com>
 docs:     https://github.com/cloudfoundry-community/blacksmith-boshrelease
 code:     https://github.com/genesis-community/blacksmith-genesis-kit

--- a/kit.yml
+++ b/kit.yml
@@ -1,6 +1,6 @@
 ---
 name:    blacksmith
-version: 0.11.4
+version: 0.11.6
 author:  James Hunt <james@niftylogic.com>
 docs:     https://github.com/cloudfoundry-community/blacksmith-boshrelease
 code:     https://github.com/genesis-community/blacksmith-genesis-kit

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -52,13 +52,13 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.4.2
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.4.2/blacksmith-1.4.2.tgz
-  sha1:    1fe5913ba4ce1bde0b90bbe56017f411d60b4325
+  version: 1.5.0
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.0/blacksmith-1.5.0.tgz
+  sha1:    65a12c44cad9766b798f2e7f3990127b90f39d59
 
 stemcells:
   - alias: default
-    os:      (( grab params.stemcell_os      || "ubuntu-xenial"))
+    os:      (( grab params.stemcell_os      || "ubuntu-bionic"))
     version: (( grab params.stemcell_version || "latest" ))
 
 update:

--- a/manifests/forges/mariadb.yml
+++ b/manifests/forges/mariadb.yml
@@ -16,9 +16,9 @@ meta:
 
 releases:
   - name:    mariadb-forge
-    version: 0.4.0
-    url:     https://github.com/blacksmith-community/mariadb-forge-boshrelease/releases/download/v0.4.0/mariadb-forge-0.4.0.tgz
-    sha1:    a6167f7d859db818191bf614de23c7baabd8525f
+    version: 0.5.0
+    url:     https://github.com/blacksmith-community/mariadb-forge-boshrelease/releases/download/v0.5.0/mariadb-forge-0.5.0.tgz
+    sha1:    e332545449e55df5cd28f9d78f83e6df62a4e4ae
 
 params:
   releases:

--- a/manifests/forges/postgresql.yml
+++ b/manifests/forges/postgresql.yml
@@ -22,9 +22,9 @@ meta:
 
 releases:
   - name:    postgresql-forge
-    version: 0.3.1
-    url:     https://github.com/blacksmith-community/postgresql-forge-boshrelease/releases/download/v0.3.1/postgresql-forge-0.3.1.tgz
-    sha1:    6ae1951b25a1b1ef19393b47a18090f133f62934
+    version: 0.4.0
+    url:     https://github.com/blacksmith-community/postgresql-forge-boshrelease/releases/download/v0.4.0/postgresql-forge-0.4.0.tgz
+    sha1:    81d5b2d0b864a02cf4f519d6029ad74503391bf5
 
 params:
   releases:
@@ -34,9 +34,9 @@ params:
       url:     https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v2.0.0/postgres-2.0.0.tgz
       sha1:    dea5cad517c62afaf97a1b31df41ad691928d960
     - name:    postgres
-      version: 3.2.1
-      url:     https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.2.1/postgres-3.2.1.tgz
-      sha1:    b687753085f770807603642b4bae6c17a483900b
+      version: 3.2.2
+      url:     https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.2.2/postgres-3.2.2.tgz
+      sha1:    7699715ed0b7ec129f60958e2864958030333cea
 
 instance_groups:
   - name: blacksmith

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -16,9 +16,9 @@ meta:
 
 releases:
   - name:    rabbitmq-forge
-    version: 0.3.0
-    url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.3.0/rabbitmq-forge-0.3.0.tgz
-    sha1:    f11eed131e9da660ffcb6ebc08ec367276a5c032
+    version: 0.4.0
+    url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.4.0/rabbitmq-forge-0.4.0.tgz
+    sha1:    3c4096834bc9c72c2499c2eb05ebbb53b2dc08b3
 
 params:
   releases:

--- a/manifests/forges/redis.yml
+++ b/manifests/forges/redis.yml
@@ -21,9 +21,9 @@ meta:
         vm_type: default
 releases:
 - name:    redis-forge
-  version: 0.6.1
-  url:     https://github.com/blacksmith-community/redis-forge-boshrelease/releases/download/v0.6.1/redis-forge-0.6.1.tgz
-  sha1:    f2d3ea11bea26771b571ecf02823b8dc7d55c1e9
+  version: 0.7.0
+  url:     https://github.com/blacksmith-community/redis-forge-boshrelease/releases/download/v0.7.0/redis-forge-0.7.0.tgz
+  sha1:    edbf7537977e04c77f8291c628023f9815d5e8c1
 
 params:
   releases:

--- a/manifests/iaas/aws.yml
+++ b/manifests/iaas/aws.yml
@@ -11,10 +11,10 @@ params:
   aws_default_sgs: (( param "What security groups should VMs be placed in, if none are specified via Cloud Config?" ))
 
   stemcells:
-    - name:    bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-      version: '621.125'
-      url:     https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.125
-      sha1:    a21e4f88d84f8fc8d7b3318cca712de2b6fd0b61
+    - name:    bosh-aws-xen-hvm-ubuntu-bionic-go_agent
+      version: '1.36'
+      url:     https://storage.googleapis.com/bosh-aws-light-stemcells/1.36/light-bosh-stemcell-1.36-aws-xen-hvm-ubuntu-bionic-go_agent.tgz
+      sha1:    4278c71c23a2f0345e445825baa9f631f15ad520
 
 releases:
   - name:    bosh-aws-cpi

--- a/manifests/iaas/azure.yml
+++ b/manifests/iaas/azure.yml
@@ -5,10 +5,10 @@ params:
   azure_default_sg:     (( param "Specify the default security group for your Azure VMs" ))
 
   stemcells:
-    - name:    bosh-azure-hyperv-ubuntu-xenial-go_agent
-      version: '621.125'
-      url:     https://bosh.io/d/stemcells/bosh-azure-hyperv-ubuntu-xenial-go_agent?v=621.125
-      sha1:    b05d331dc762214388d6e7196bc235e9ac2e0b0a
+    - name:    bosh-azure-hyperv-ubuntu-bionic-go_agent
+      version: '1.36'
+      url:     https://storage.googleapis.com/bosh-core-stemcells/1.36/bosh-stemcell-1.36-azure-hyperv-ubuntu-bionic-go_agent.tgz
+      sha1:    6d51e4628cd6557f2a6d64350ce7d697b7a34e47
 
 releases:
   - name:    bosh-azure-cpi

--- a/manifests/iaas/google.yml
+++ b/manifests/iaas/google.yml
@@ -10,10 +10,10 @@ params:
     - time4.google.com
 
   stemcells:
-    - name:    bosh-google-kvm-ubuntu-xenial-go_agent
-      version: '621.125'
-      url:     https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=621.125
-      sha1:    acd1bda34939c523a047d6274843bbdde2efb8b7
+    - name:    bosh-google-kvm-ubuntu-bionic-go_agent
+      version: '1.36'
+      url:     https://storage.googleapis.com/bosh-gce-light-stemcells/1.36/light-bosh-stemcell-1.36-google-kvm-ubuntu-bionic-go_agent.tgz
+      sha1:    962c958e17012bd8bd003568f7978c465d83d12b
 
 releases:
   - name:    bosh-google-cpi

--- a/manifests/iaas/openstack.yml
+++ b/manifests/iaas/openstack.yml
@@ -10,10 +10,10 @@ params:
   openstack_default_security_groups: (( param "What OpenStack SGs are applied to VMs by default?" ))
 
 stemcells:
-  - name:    bosh-openstack-kvm-ubuntu-xenial-go_agent
-    version: '621.125'
-    url:     https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=621.125
-    sha1:    4ac4a2b5e1c2f210ec952eaa73df2691a6525e67
+  - name:    bosh-openstack-kvm-ubuntu-bionic-go_agent
+    version: '1.36'
+    url:     https://storage.googleapis.com/bosh-core-stemcells/1.36/bosh-stemcell-1.36-openstack-kvm-ubuntu-bionic-go_agent.tgz
+    sha1:    a444fe21177db5b0dfcb116d58fb566707c2e36c
 
 releases:
   - name:    bosh-openstack-cpi

--- a/manifests/iaas/vsphere.yml
+++ b/manifests/iaas/vsphere.yml
@@ -11,10 +11,10 @@ params:
   vsphere_datacenter:            (( param "Please specify your vSphere Datacenter Name" ))
 
   stemcells:
-    - name:    bosh-vsphere-esxi-ubuntu-xenial-go_agent
-      version: '621.125'
-      url:     https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=621.125
-      sha1:    7724ce4272dd8f19b44584a17d31595eac7595e5
+    - name:    bosh-vsphere-esxi-ubuntu-bionic-go_agent
+      version: '1.36'
+      url:     https://storage.googleapis.com/bosh-core-stemcells/1.36/bosh-stemcell-1.36-vsphere-esxi-ubuntu-bionic-go_agent.tgz
+      sha1:    4cf0de2078b94dfdeb01ac6e3af7a32c31df5171
 
 releases:
   - name:    bosh-vsphere-cpi


### PR DESCRIPTION
# Software Updates:

Updated all Forges and Embedded Blacksmith to use Bionic Stemcells
* Updated MariaDB Forge to 10.4.22
* Updated PostgreSQL forge to 9.5.25
* Updated Redis Forge to 5.0.14 and 6.2.6
* Updated RabbitMQ forge to 3.7.28
* Bump all default stemcells to Bionic 1.36

# Deprecation Notice

* Future releases of embedded BOSH will drop vCenter 6.0 support