### PR TITLE
updated meta path and port defaults

### DIFF
--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -11,10 +11,10 @@ meta:
     azs: [z1]
     host: (( grab params.fqdn || params.ip ))
     scheme: http
-    blacksmith_port: 3000
+    blacksmith_port: (( grab params.blacksmith_port || 3000 ))
 
 exodus:
-  broker_url: (( concat meta.scheme "://" meta.host ":" params.blacksmith_port ))
+  broker_url: (( concat meta.default.scheme "://" meta.default.host ":" meta.default.blacksmith_port ))
   broker_username: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.broker.username ))
   broker_password: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.broker.password ))
   bosh_username: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.bosh.username ))


### PR DESCRIPTION
Recent meta changes provide the following values:

* host
* scheme
* blacksmith_port

exodus data on the other hand was failing to retrieve them causing the following errors:

```
STDOUT:
1 error(s) detected:
 - $.exodus.broker_url: Unable to resolve `meta.host`: `$.meta.host` could not be found in the datastructure
```

```
STDOUT:
1 error(s) detected:
 - $.exodus.broker_url: Unable to resolve `params.blacksmith_port`: `$.params.blacksmith_port` could not be found in the datastructure
```

The proposed changes:

* fixes the meta path from `meta.key` to `meta.default.key` on the exodus block for `broker_url`,
* removes the requirement to provide a `blacksmith_port` parameter (defaults to 3000) by
* utilizing the `meta.default.blacksmith_port` value  on the exodus block for `broker_url` and
* updates the `meta.default.blacksmith_port` with a `params.` reference *and* a default (`||`) port number