### PR TITLE
Rabbtimq

### DIFF
--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -61,7 +61,7 @@ instance_groups:
             cloud-config: (( grab params.cloud_config ))
         blacksmith_services_ca:
           tls:
-            ca_cert: ((blacksmith_services_ca.certificate))
+            ca_cert: ((blacksmith_services_ca.ca))
 
 releases:
 - name:    blacksmith

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.5.3
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.3/blacksmith-1.5.3.tgz
-  sha1:    0186e9bea38e755477cefbd6401e479b4f7e0d96
+  version: 1.5.3b
+  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.3b.tgz
+  sha1:    7bcd47d36a44880f16b9653577c278c6908f6376
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -59,9 +59,9 @@ instance_groups:
             stemcells:    (( grab params.stemcells ))
             releases:     (( grab params.releases ))
             cloud-config: (( grab params.cloud_config ))
-        blacksmith_services_ca:
-          tls:
-            ca_cert: ((blacksmith_services_ca.certificate))
+          blacksmith_services_ca:
+            tls:
+              ca_cert: ((blacksmith_services_ca.certificate))
 
 releases:
 - name:    blacksmith

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.5.3
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.3/blacksmith-1.5.3.tgz
-  sha1:    0186e9bea38e755477cefbd6401e479b4f7e0d96
+  version: 1.5.3b
+  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.b.tgz
+  sha1:    7bcd47d36a44880f16b9653577c278c6908f6376
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -61,7 +61,7 @@ instance_groups:
             cloud-config: (( grab params.cloud_config ))
         blacksmith_services_ca:
           tls:
-            ca_cert: ((blacksmith_services_ca.ca))
+            ca_cert: ((blacksmith_services_ca.certificate))
 
 releases:
 - name:    blacksmith

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -62,9 +62,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.5.2
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.2/blacksmith-1.5.2.tgz
-  sha1:    34b33acf4de8b70f38860658bdaa9b04ffd59108
+  version: 1.5.3
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.3/blacksmith-1.5.3.tgz
+  sha1:    0186e9bea38e755477cefbd6401e479b4f7e0d96
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -22,6 +22,13 @@ exodus:
   bosh_address: (( grab instance_groups.blacksmith.jobs.blacksmith.properties.bosh.address ))
   bosh_cacert: (( vault meta.vault "/tls/ca:certificate" ))
 
+variables:
+- name: blacksmith_services_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: (( concat params.env "-blacksmith-services-ca.bosh" ))
+
 instance_groups:
   - name:      blacksmith
     instances: 1

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -66,7 +66,7 @@ instance_groups:
 releases:
 - name:    blacksmith
   version: 1.5.3b
-  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.b.tgz
+  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.3b.tgz
   sha1:    7bcd47d36a44880f16b9653577c278c6908f6376
 
 stemcells:

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.6.1
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.6.1/blacksmith-1.6.1.tgz
-  sha1:    1bf5483d581092f3d8267daf99f261a22f1f65a9
+  version: 1.6.5
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.6.5/blacksmith-1.6.5.tgz
+  sha1:    1def8e4e21d3ea95aaf16339d4dec64667538ae9
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.5.3b
-  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.3b.tgz
-  sha1:    7bcd47d36a44880f16b9653577c278c6908f6376
+  version: 1.6.1
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.6.1/blacksmith-1.6.1.tgz
+  sha1:    1bf5483d581092f3d8267daf99f261a22f1f65a9
 
 stemcells:
   - alias: default

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -59,6 +59,9 @@ instance_groups:
             stemcells:    (( grab params.stemcells ))
             releases:     (( grab params.releases ))
             cloud-config: (( grab params.cloud_config ))
+        blacksmith_services_ca:
+          tls:
+            ca_cert: ((blacksmith_services_ca.certificate))
 
 releases:
 - name:    blacksmith

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.5.3b
-  url:     https://github.com/itsouvalas/blacksmith-boshrelease/releases/download/v1.5.3b/blacksmith-1.5.3b.tgz
-  sha1:    7bcd47d36a44880f16b9653577c278c6908f6376
+  version: 1.5.3
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.5.3/blacksmith-1.5.3.tgz
+  sha1:    0186e9bea38e755477cefbd6401e479b4f7e0d96
 
 stemcells:
   - alias: default

--- a/manifests/forges/rabbitmq-dashboard-registration.yml
+++ b/manifests/forges/rabbitmq-dashboard-registration.yml
@@ -4,6 +4,8 @@ meta:
     exodus: (( concat $GENESIS_EXODUS_MOUNT params.cf.deployment_env "/" params.cf.deployment_type ))
   bosh:
     exodus_path: (( grab params.bosh_exodus_path || genesis.bosh || params.bosh || genesis.env || params.env ))
+    env_name: (( grab genesis.bosh_env || genesis.bosh || params.bosh || genesis.env || params.env ))
+    
 params:
   cf: &cf
     deployment_env:  (( grab genesis.env )) # assume the same env name as cf env
@@ -20,7 +22,7 @@ instance_groups:
         cf:
           <<: *cf
         bosh:
-          deployment_name: ((grab meta.bosh.exodus_path))
+          deployment_name: ((grab meta.bosh.env_name))
         rabbitmq:
            route_registrar:
              enabled: true

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -29,6 +29,7 @@ variables:
   type: certificate
   options:
     is_ca: true
+    common_name: (( concat meta.environment "-blacksmith-rabbitmq-services.bosh" ))
 
 releases:
 - name:    rabbitmq-forge

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15z
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15z/rabbitmq-forge-0.5.15z.tgz
-  sha1:    fcef4acdb66b08a88c90c5ec28b1c8c8e56f4ce8
+  version: 0.5.16a
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16a/rabbitmq-forge-0.5.16a.tgz
+  sha1:    fa244631b5ce60fc2ce395671768a47be4fad184
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -24,13 +24,12 @@ meta:
         type: standalone
         vm_type: default
 
-
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.18f
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.18f/rabbitmq-forge-0.5.18f.tgz
-  sha1:    22eccc12afb40ff0e1afe4649c903e8de25f22ba
-
+  version: 0.7.0
+  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.7.0/rabbitmq-forge-0.7.0.tgz
+  sha1:    efd951065ee74546338d215a55f02ad349967f73
+  
 params:
   releases:
     - (( append ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15u
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15u/rabbitmq-forge-0.5.15u.tgz
-  sha1:    836e408967d57e18aa8bab4404a65f10d1acb507
+  version: 0.5.15v
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15v/rabbitmq-forge-0.5.15v.tgz
+  sha1:    d245ac5765cec02d2fdd8930f56e5b99afc8284d
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -1,10 +1,9 @@
 ---
 meta:
   environment: (( grab genesis.env || params.env ))
-  bosh_exodus_path: (( grab params.bosh_exodus_path || genesis.bosh || params.bosh || genesis.env || params.env ))
 
   cf:
-    exodus_path: (( concat "secret/exodus/" meta.bosh_exodus_path "/cf" ))
+    exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))
     system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
     api_url:    (( concat "https://api." meta.cf.system_domain ))
@@ -20,7 +19,7 @@ meta:
     rabbitmq_plans:
       standalone:
         name: standalone
-        description: A dedicated RabbitMQ server, with no redundancy or replication
+        :q: A dedicated RabbitMQ server, with no redundancy or replication
         limit: 7
         type: standalone
         vm_type: default
@@ -43,7 +42,6 @@ instance_groups:
         name:    rabbitmq-blacksmith-plans
         properties:
           environment: (( grab meta.environment ))
-          bosh_exodus_path: (( grab meta.bosh_exodus_path ))
           cf:
             exodus_path: (( grab meta.cf.exodus_path ))
             deployment_name: (( grab meta.cf.deployment_name ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,8 +26,8 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15y
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15y/rabbitmq-forge-0.5.15y.tgz
+  version: 0.5.15z
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15z/rabbitmq-forge-0.5.15z.tgz
   sha1:    fded2c921e73e59330b58553e911a492fb731e7e
 
 params:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16a
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16a/rabbitmq-forge-0.5.16a.tgz
-  sha1:    fa244631b5ce60fc2ce395671768a47be4fad184
+  version: 0.5.16b
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16b/rabbitmq-forge-0.5.16b.tgz
+  sha1:    947a9eba3e5e9c043c1eee9aece0186fcb2d74c2
 
 params:
   releases:
@@ -66,6 +66,8 @@ instance_groups:
               skip_ssl_validation: (( grab params.cf_skip_ssl_validation ))
               username:   (( vault meta.cf.exodus_path ":admin_username" ))
               password:   (( vault meta.cf.exodus_path ":admin_password" ))
+            rmq_management:
+              skip_ssl_validation: (( grab params.emitter_skip_ssl_validation ))
           
 
           plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16l
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16l/rabbitmq-forge-0.5.16l.tgz
-  sha1:    88a7aab13937155b5001f044be4824f3b7b6d3cf
+  version: 0.5.16m
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16m/rabbitmq-forge-0.5.16m.tgz
+  sha1:    870308b5300426f31354cc801277e309ae9e3244
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -70,10 +70,10 @@ instance_groups:
               username:   (( vault meta.cf.exodus_path ":admin_username" ))
               password:   (( vault meta.cf.exodus_path ":admin_password" ))
             rmq_management:
-              skip_ssl_validation: (( grab params.emitter_skip_ssl_validation ))
-              mgmt_port: (( grab params.emitter_mgmt_port ))
-              mgmt_scheme: (( grab params.emitter_scheme ))
-              mgmt_host: (( grab params.emitter_mgmt_host ))
+              skip_ssl_validation: (( grab params.emitter_skip_ssl_validation || true ))
+              mgmt_port: (( grab params.emitter_mgmt_port || "15671" ))
+              mgmt_scheme: (( grab params.emitter_scheme || "https" ))
+              mgmt_host: (( grab params.emitter_mgmt_host || "localhost" ))
           blacksmith_rabbitmq_services:
             tls:
               ca_cert: ((blacksmith_rabbitmq_services_ca.certificate))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15h
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15h/rabbitmq-forge-0.5.15h.tgz
-  sha1:    b18eac76acab49898836f12d2373d0b326fb8172
+  version: 0.5.15i
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15i/rabbitmq-forge-0.5.15i.tgz
+  sha1:    d8d0a659fde3fb7fbb946f0c4b7b24b430a4f621
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16o
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16o/rabbitmq-forge-0.5.16o.tgz
-  sha1:    7e319cbdb39eba75cdbf7bb9a07022fb9bc48d7e
+  version: 0.5.16p
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16p/rabbitmq-forge-0.5.16p.tgz
+  sha1:    6b88da3fbd7eb5ddb38815de550a39b2ee17b02a
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -1,5 +1,16 @@
 ---
 meta:
+  environment: (( grab genesis.env || params.env ))
+  bosh_exodus_path: (( grab params.bosh_exodus_path || genesis.bosh || params.bosh || genesis.env || params.env ))
+
+  cf:
+    exodus_path: (( concat "secret/exodus/" meta.bosh_exodus_path "/cf" ))
+    deployment_name: (( concat meta.environment "-cf" ))
+    system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
+    api_url:    (( concat "https://api." meta.cf.system_domain ))
+    username:   (( vault meta.cf.exodus_path ":admin_username" ))
+    password:   (( vault meta.cf.exodus_path ":admin_password" ))
+
   default:
     rabbitmq_tags:
       - blacksmith
@@ -31,6 +42,16 @@ instance_groups:
       - release: rabbitmq-forge
         name:    rabbitmq-blacksmith-plans
         properties:
+          environment: (( grab meta.environment ))
+          bosh_exodus_path: (( grab meta.bosh_exodus_path ))
+          cf:
+            exodus_path: (( grab meta.cf.exodus_path ))
+            deployment_name: (( grab meta.cf.deployment_name ))
+            system_domain: (( grab meta.cf.system_domain ))
+            api_url:    (( grab meta.cf.api_url ))
+            username:   (( grab meta.cf.username ))
+            password:   (( grab meta.cf.password ))
+
           plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
           service:
             id:          (( grab params.rabbitmq_service_id          || "rabbitmq" ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.7.5
-  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.7.5/rabbitmq-forge-0.7.5.tgz
-  sha1:    aafa05bc089b51e8fc204683cd933e9af6cbbef5
+  version: 0.7.12
+  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.7.12/rabbitmq-forge-0.7.12.tgz
+  sha1:    07d4f2d90ab162b9811f22a115f064f9ffd2c873
   
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15s
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15s/rabbitmq-forge-0.5.15s.tgz
-  sha1:    e72fb0e02ac7b27fa742052bf9a0ece1a238bb9b
+  version: 0.5.15t
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15t/rabbitmq-forge-0.5.15t.tgz
+  sha1:    eb97c4f528960697036f9d2bdffdcab39f9f192a
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16f
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16f/rabbitmq-forge-0.5.16f.tgz
-  sha1:    053203aa94fb0b8925049933558d1d35a34cf9ef
+  version: 0.5.16g
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16g/rabbitmq-forge-0.5.16g.tgz
+  sha1:    474aec08a272b342e234f2e8776cd63ca9dd5447
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -34,6 +34,7 @@ params:
   releases:
     - (( append ))
     - (( grab releases.rabbitmq-forge ))
+  cf_skip_ssl_validation: false
 
 instance_groups:
   - name: blacksmith
@@ -55,10 +56,10 @@ instance_groups:
               agent:
                 cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
                 key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
-          metrics:
-            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
-            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
-            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
+#          metrics:
+#            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
+#            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
+#            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
           rabbitmq_metrics_emitter:
             cloud_foundry:
               api:    (( grab meta.cf.api_url ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15v
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15v/rabbitmq-forge-0.5.15v.tgz
-  sha1:    d245ac5765cec02d2fdd8930f56e5b99afc8284d
+  version: 0.5.15y
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15y/rabbitmq-forge-0.5.15y.tgz
+  sha1:    fded2c921e73e59330b58553e911a492fb731e7e
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16h
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16h/rabbitmq-forge-0.5.16h.tgz
-  sha1:    f0c6ebec4b40106ea52959608c46cb31399b9354
+  version: 0.5.16i
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16i/rabbitmq-forge-0.5.16i.tgz
+  sha1:    6e56150050bd79bd173f2edee01659271e3011bb
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16g
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16g/rabbitmq-forge-0.5.16g.tgz
-  sha1:    474aec08a272b342e234f2e8776cd63ca9dd5447
+  version: 0.5.16h
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16h/rabbitmq-forge-0.5.16h.tgz
+  sha1:    f0c6ebec4b40106ea52959608c46cb31399b9354
 
 params:
   releases:
@@ -71,6 +71,9 @@ instance_groups:
               password:   (( vault meta.cf.exodus_path ":admin_password" ))
             rmq_management:
               skip_ssl_validation: (( grab params.emitter_skip_ssl_validation ))
+              mgmt_port: (( grab params.emitter_mgmt_port ))
+              mgmt_scheme: (( grab params.emitter_scheme ))
+              mgmt_host: (( grab params.emitter_mgmt_host ))
           blacksmith_rabbitmq_services:
             tls:
               ca_cert: ((blacksmith_rabbitmq_services_ca.certificate))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16j
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16j/rabbitmq-forge-0.5.16j.tgz
-  sha1:    b2b091293641fd7130a19cbd0d2911bc8e694dc7
+  version: 0.5.16k
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16k/rabbitmq-forge-0.5.16k.tgz
+  sha1:    7a979a7b2381254f2fc4219cbc34cbf81c5eded1
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16d
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16d/rabbitmq-forge-0.5.16d.tgz
-  sha1:    c54c52cef84abfa4491c5591f444980d38fc8250
+  version: 0.5.16e
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16e/rabbitmq-forge-0.5.16e.tgz
+  sha1:    a7ca27647b81556c465968673608fe179dca9d20
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15n
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15n/rabbitmq-forge-0.5.15n.tgz
-  sha1:    7183b9703e4260bd8546f1553e2ea4bd765701ed
+  version: 0.5.15o
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15o/rabbitmq-forge-0.5.15o.tgz
+  sha1:    a37a53a07335ea74ea73d64740eb29c891676cc1
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15i
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15i/rabbitmq-forge-0.5.15i.tgz
-  sha1:    d8d0a659fde3fb7fbb946f0c4b7b24b430a4f621
+  version: 0.5.15j
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15j/rabbitmq-forge-0.5.15j.tgz
+  sha1:    436c8a0260e839be686cb461074809420d71861e
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -1,7 +1,7 @@
 ---
 meta:
-  environment: (( grab genesis.bosh_env || params.env ))
-
+  environment: (( grab genesis.env || params.env ))
+  bosh_env: (( grab genesis.bosh_env || params.bosh_env))
   cf:
     exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))
@@ -43,6 +43,7 @@ instance_groups:
         name:    rabbitmq-blacksmith-plans
         properties:
           environment: (( grab meta.environment ))
+          bosh_env: (( grab meta.bosh_env ))
           cf:
             exodus_path: (( grab meta.cf.exodus_path ))
             deployment_name: (( grab meta.cf.deployment_name ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  environment: (( grab genesis.env || params.env ))
+  environment: (( grab genesis.bosh_env || params.env ))
 
   cf:
     exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -24,18 +24,12 @@ meta:
         type: standalone
         vm_type: default
 
-variables:
-- name: blacksmith_rabbitmq_services_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: (( concat meta.environment "-blacksmith-rabbitmq-services.bosh" ))
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16q
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16q/rabbitmq-forge-0.5.16q.tgz
-  sha1:    2a8de8dcff413f230abc43017eb3bab26cc0b6a5
+  version: 0.5.18f
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.18f/rabbitmq-forge-0.5.18f.tgz
+  sha1:    22eccc12afb40ff0e1afe4649c903e8de25f22ba
 
 params:
   releases:
@@ -74,9 +68,6 @@ instance_groups:
               mgmt_port: (( grab params.emitter_mgmt_port || "15671" ))
               mgmt_scheme: (( grab params.emitter_scheme || "https" ))
               mgmt_host: (( grab params.emitter_mgmt_host || "localhost" ))
-          blacksmith_rabbitmq_services:
-            tls:
-              ca_cert: ((blacksmith_rabbitmq_services_ca.certificate))
 
           plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
           service:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15q
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15q/rabbitmq-forge-0.5.15q.tgz
-  sha1:    176481862dad08b4b012c0e67becfe344f14aae1
+  version: 0.5.15r
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15r/rabbitmq-forge-0.5.15r.tgz
+  sha1:    951dd785f08ac0672fbbe56b315a65b2385f6182
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15o
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15o/rabbitmq-forge-0.5.15o.tgz
-  sha1:    a37a53a07335ea74ea73d64740eb29c891676cc1
+  version: 0.5.15p
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15p/rabbitmq-forge-0.5.15p.tgz
+  sha1:    c571f1efd058e1c0fa5d73454b3c5422b5a97265
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16e
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16e/rabbitmq-forge-0.5.16e.tgz
-  sha1:    a7ca27647b81556c465968673608fe179dca9d20
+  version: 0.5.16f
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16f/rabbitmq-forge-0.5.16f.tgz
+  sha1:    053203aa94fb0b8925049933558d1d35a34cf9ef
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -1,7 +1,7 @@
 ---
 meta:
   environment: (( grab genesis.env || params.env ))
-  bosh_env: (( grab genesis.bosh_env || params.bosh_env))
+  bosh_env: (( grab genesis.bosh_env || params.bosh_env || params.env ))
   cf:
     exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16n
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16n/rabbitmq-forge-0.5.16n.tgz
-  sha1:    f355ce61e140c307933841b71b7b167d2dc42006
+  version: 0.5.16o
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16o/rabbitmq-forge-0.5.16o.tgz
+  sha1:    7e319cbdb39eba75cdbf7bb9a07022fb9bc48d7e
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15r
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15r/rabbitmq-forge-0.5.15r.tgz
-  sha1:    951dd785f08ac0672fbbe56b315a65b2385f6182
+  version: 0.5.15s
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15s/rabbitmq-forge-0.5.15s.tgz
+  sha1:    e72fb0e02ac7b27fa742052bf9a0ece1a238bb9b
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16m
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16m/rabbitmq-forge-0.5.16m.tgz
-  sha1:    870308b5300426f31354cc801277e309ae9e3244
+  version: 0.5.16n
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16n/rabbitmq-forge-0.5.16n.tgz
+  sha1:    f355ce61e140c307933841b71b7b167d2dc42006
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15j
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15j/rabbitmq-forge-0.5.15j.tgz
-  sha1:    436c8a0260e839be686cb461074809420d71861e
+  version: 0.5.15k
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15k/rabbitmq-forge-0.5.15k.tgz
+  sha1:    10cb08b2b6d1c2a6d6d9f8a2dd9c324c6c01a79d
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16p
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16p/rabbitmq-forge-0.5.16p.tgz
-  sha1:    6b88da3fbd7eb5ddb38815de550a39b2ee17b02a
+  version: 0.5.16q
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16q/rabbitmq-forge-0.5.16q.tgz
+  sha1:    2a8de8dcff413f230abc43017eb3bab26cc0b6a5
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15l
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15l/rabbitmq-forge-0.5.15l.tgz
-  sha1:    caf09fcd70d1c936856b7f38625f73ed72a2804b
+  version: 0.5.15m
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15m/rabbitmq-forge-0.5.15m.tgz
+  sha1:    7897606f0020ad705e91f701acf13e43be75d497
 
 params:
   releases:
@@ -49,6 +49,23 @@ instance_groups:
             api_url:    (( grab meta.cf.api_url ))
             username:   (( grab meta.cf.username ))
             password:   (( grab meta.cf.password ))
+          loggregator:
+            tls:
+              ca_cert: (( vault meta.cf.exodus_path ":loggregator_ca" ))
+              agent:
+                cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
+                key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
+          metrics:
+            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
+            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
+            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
+          rabbitmq_metrics_emitter:
+            cloud_foundry:
+              api:    (( grab meta.cf.api_url ))
+              skip_ssl_validation: (( grab params.cf_skip_ssl_validation ))
+              username:   (( vault meta.cf.exodus_path ":admin_username" ))
+              password:   (( vault meta.cf.exodus_path ":admin_password" ))
+          
 
           plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
           service:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -19,7 +19,7 @@ meta:
     rabbitmq_plans:
       standalone:
         name: standalone
-        :q: A dedicated RabbitMQ server, with no redundancy or replication
+        description: A dedicated RabbitMQ server, with no redundancy or replication
         limit: 7
         type: standalone
         vm_type: default

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16b
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16b/rabbitmq-forge-0.5.16b.tgz
-  sha1:    947a9eba3e5e9c043c1eee9aece0186fcb2d74c2
+  version: 0.5.16c
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16c/rabbitmq-forge-0.5.16c.tgz
+  sha1:    6bb79c6f54f9091418085ba3253924dd2af6643b
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.7.0
-  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.7.0/rabbitmq-forge-0.7.0.tgz
-  sha1:    efd951065ee74546338d215a55f02ad349967f73
+  version: 0.7.5
+  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.7.5/rabbitmq-forge-0.7.5.tgz
+  sha1:    aafa05bc089b51e8fc204683cd933e9af6cbbef5
   
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15m
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15m/rabbitmq-forge-0.5.15m.tgz
-  sha1:    7897606f0020ad705e91f701acf13e43be75d497
+  version: 0.5.15n
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15n/rabbitmq-forge-0.5.15n.tgz
+  sha1:    7183b9703e4260bd8546f1553e2ea4bd765701ed
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15p
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15p/rabbitmq-forge-0.5.15p.tgz
-  sha1:    c571f1efd058e1c0fa5d73454b3c5422b5a97265
+  version: 0.5.15q
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15q/rabbitmq-forge-0.5.15q.tgz
+  sha1:    176481862dad08b4b012c0e67becfe344f14aae1
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16i
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16i/rabbitmq-forge-0.5.16i.tgz
-  sha1:    6e56150050bd79bd173f2edee01659271e3011bb
+  version: 0.5.16j
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16j/rabbitmq-forge-0.5.16j.tgz
+  sha1:    b2b091293641fd7130a19cbd0d2911bc8e694dc7
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15g
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15g/rabbitmq-forge-0.5.15g.tgz
-  sha1:    c33a4509bfc6b5c148971986bedd98a0c19dbffc
+  version: 0.5.15h
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15h/rabbitmq-forge-0.5.15h.tgz
+  sha1:    b18eac76acab49898836f12d2373d0b326fb8172
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15t
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15t/rabbitmq-forge-0.5.15t.tgz
-  sha1:    eb97c4f528960697036f9d2bdffdcab39f9f192a
+  version: 0.5.15u
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15u/rabbitmq-forge-0.5.15u.tgz
+  sha1:    836e408967d57e18aa8bab4404a65f10d1acb507
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -24,11 +24,17 @@ meta:
         type: standalone
         vm_type: default
 
+variables:
+- name: blacksmith_rabbitmq_services_ca
+  type: certificate
+  options:
+    is_ca: true
+
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16c
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16c/rabbitmq-forge-0.5.16c.tgz
-  sha1:    6bb79c6f54f9091418085ba3253924dd2af6643b
+  version: 0.5.16d
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16d/rabbitmq-forge-0.5.16d.tgz
+  sha1:    c54c52cef84abfa4491c5591f444980d38fc8250
 
 params:
   releases:
@@ -56,10 +62,6 @@ instance_groups:
               agent:
                 cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
                 key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
-#          metrics:
-#            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
-#            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
-#            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
           rabbitmq_metrics_emitter:
             cloud_foundry:
               api:    (( grab meta.cf.api_url ))
@@ -68,7 +70,9 @@ instance_groups:
               password:   (( vault meta.cf.exodus_path ":admin_password" ))
             rmq_management:
               skip_ssl_validation: (( grab params.emitter_skip_ssl_validation ))
-          
+          blacksmith_rabbitmq_services:
+            tls:
+              ca_cert: ((blacksmith_rabbitmq_services_ca.certificate))
 
           plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
           service:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -33,9 +33,9 @@ variables:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.16k
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16k/rabbitmq-forge-0.5.16k.tgz
-  sha1:    7a979a7b2381254f2fc4219cbc34cbf81c5eded1
+  version: 0.5.16l
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.16l/rabbitmq-forge-0.5.16l.tgz
+  sha1:    88a7aab13937155b5001f044be4824f3b7b6d3cf
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -28,7 +28,7 @@ releases:
 - name:    rabbitmq-forge
   version: 0.5.15z
   url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15z/rabbitmq-forge-0.5.15z.tgz
-  sha1:    fded2c921e73e59330b58553e911a492fb731e7e
+  sha1:    fcef4acdb66b08a88c90c5ec28b1c8c8e56f4ce8
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -26,9 +26,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.15k
-  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15k/rabbitmq-forge-0.5.15k.tgz
-  sha1:    10cb08b2b6d1c2a6d6d9f8a2dd9c324c6c01a79d
+  version: 0.5.15l
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15l/rabbitmq-forge-0.5.15l.tgz
+  sha1:    caf09fcd70d1c936856b7f38625f73ed72a2804b
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -16,9 +16,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 0.5.13
-  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v0.5.13/rabbitmq-forge-0.5.13.tgz
-  sha1:    74866b6ec5a2c577ead599e0ed34bb94b8b6a754
+  version: 0.5.15g
+  url:     https://github.com/itsouvalas/rabbitmq-forge-boshrelease/releases/download/v0.5.15g/rabbitmq-forge-0.5.15g.tgz
+  sha1:    c33a4509bfc6b5c148971986bedd98a0c19dbffc
 
 params:
   releases:


### PR DESCRIPTION
Blacksmith
* Adds `blacksmith_services_ca`
Rabbitmq
* Adds meta information for environment/bosh_env and cf
* Uses env_name instead of exodus_path to allow for a different value between the two
* Defaults to rabbitmq-forge 0.7.12
* Moves the meta to properties to be used by forges
