### PR TITLE
adding missing name attribute on pipeline manifest

### DIFF
--- a/ci/envs/ci-gcp-baseline.yml
+++ b/ci/envs/ci-gcp-baseline.yml
@@ -36,6 +36,7 @@ params:
   # see https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/blob/master/README.md
   rabbitmq_plans:
     dedicated:
+      name:    dedicated
       type:    standalone
       vm_type: rabbitmq
       network: blacksmith
@@ -43,6 +44,7 @@ params:
 
     # for backing a shared RabbitMQ cluster
     cluster:
+      name:    cluster
       type:    cluster
       vm_type: rabbitmq
       network: blacksmith


### PR DESCRIPTION
resolves:

```
                     L Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'blacksmith'. Errors are:
    - Unable to render templates for job 'rabbitmq-blacksmith-plans'. Errors are:
      - Error filling in template 'configure-blacksmith' (line 15: undefined method `tr' for nil:NilClass
      Did you mean?  try)
```