### PR TITLE
rmq dynamic credentials/doc

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+# Features
+
+* RabbitMQ Dynamic Credentials @itsouvalas
+
+The dynamic credentials feature extends the predefined static credentials with new, unique credentials created each time an application is bound to the RabbitMQ service or a service key is created against that same service. As a result, operators can rely on the static credentials for monitoring, application testing and administering the RabbitMQ service while relying on dynamic credentials for each of the application bindings or service keys created.
+
+# Bugs
+
+* Remove failing bosh cleanup - relying on external bosh director @itsouvalas
+
+# Documentation
+
+* Update rabbitmq-walkthrough with dynamic credentials testing

--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -65,9 +65,9 @@ instance_groups:
 
 releases:
 - name:    blacksmith
-  version: 1.6.5
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.6.5/blacksmith-1.6.5.tgz
-  sha1:    1def8e4e21d3ea95aaf16339d4dec64667538ae9
+  version: 1.6.8
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v1.6.8/blacksmith-1.6.8.tgz
+  sha1:    c31a8a854823806d2a50083eddced543eb392284
 
 stemcells:
   - alias: default

--- a/rabbitmq-walkthrough.md
+++ b/rabbitmq-walkthrough.md
@@ -177,7 +177,7 @@ rmqlarge          rabbitmq   large-single-node                create succeeded  
 rmqsmall          rabbitmq   single-node                      create succeeded   dev-blacksmith   no
 ```
 
-## Binding the service
+## <a name="binding"></a>Binding the service
 
 As much as everyone would like to have (all the) services available to them at all times, its when using them that makes a difference. To use rabbitmq you need to bind it to an application. For the requirements of this document, lets go ahead and clone a forked version of [cf-rabbitmq-example-app](https://github.com/itsouvalas/cf-rabbitmq-example-app):
 
@@ -234,7 +234,7 @@ memory usage:   256M
 
 We are now ready to run our tests and verify that the service and its features are available to the application.
 
-# Rabbitmq Testing
+# <a name="testing"></a>Rabbitmq Testing
 
 We saw that everything went fine so far, but unless we take that in good faith we can't really confirm that the application and the service is working as expected. Given that `good faith` is rarely something we rely on, lets go ahead and see for ourselves:
 
@@ -355,7 +355,7 @@ VCAP_SERVICES={"rabbitmq":[{
 }]}
 ```
 
-## Service key creation
+## <a name="service-key"></a>Service key creation
 
 Blacksmith uses the same `bind` function to bind the credentials seen earlier to a service key to be used outside that specific application:
 
@@ -497,7 +497,7 @@ SUCCESS
 Hello
 ```
 
-## Permissions
+## <a name="permissions"></a>Permissions
 
 With everything working we know that we have enough privileges to reach out to the deployed service, but since seeing is believing lets go ahead and take a look:
 
@@ -898,6 +898,300 @@ Connection to 10.7.18.17 5671 port [tcp/amqps] succeeded!
 ```
 Connection to 10.7.18.17 5672 port [tcp/amqp] succeeded!
 ```
+
+# Dynamic Credentials
+
+Our past implementation of credentials handling relied on the creation of three types of users, admin, monitoring, and application, all of which were created during the creation of the service instance itself. The monitoring and application users were available to each application bound to the service instance or to each service key created against that service. Even though an application could be unbound from the Rabbitmq service or have the service key deleted, given the static nature of the credentials, those would still be able to communicate with RabbitMQ untill that service instance was deleted.
+
+The dynamic credentials feature extends the predefined static credentials with new, unique credentials created each time an applicaiton is bound to the RabbitMQ service or a service key is created against that same service. As a result, operators can rely on the static credentials for monitoring, application testing and administering the RabbitMQ service while relying on dynamic credentials for each of the application bindings or service keys created.
+
+## Creating dynamic credentials
+
+The process is now embeded to the [Binding the service](#binding) and [Service key creation](#service-key) process defined earlier.
+
+## Testing dynamic credentials
+
+For generalized tests of the service, if you haven't done so already, you can go through the [Rabbitmq Testing](testing) process.
+
+## Confirming the dynamic nature of credentials
+
+### Environment Variables
+
+`cf env rabbitmq` # replace with the application name bound to rabbitm's service
+
+```yaml
+Getting env variables for app rabbitmq in org system / space dev as admin...
+System-Provided:
+VCAP_SERVICES: {
+  "rabbitmq": [
+    {
+      "binding_guid": "2e5552dd-94da-4768-aeca-ffb664ebce86",
+      "binding_name": null,
+      "credentials": {
+        "api_url": "https://rabbitmq-single-node-070318e0-bed8-4263-993e-1c3f5e8f1ec4.system.codex2.starkandwayne.com/api",
+        "credential_type": "dynamic",
+        "dashboard_url": "https://rabbitmq-single-node-070318e0-bed8-4263-993e-1c3f5e8f1ec4.system.codex2.starkandwayne.com/#/login/3EfZvJt0QOxtDZCQfcwsVvQqxv58w3S3T7tRIh408e96gCHHBrn7bviYjxzzHUO3/67vg3KdmZ7x79VjVod6yRtXpeQnn19ztGlP6uCNplXLSxGRzpy3mTo4pO9dFnC9g",
+        "host": "10.7.16.22",
+        "hostname": "10.7.16.22",
+        "hostnames": [
+          "10.7.16.22"
+        ],
+        "mgmt_port": 15672,
+        "monitoring_password": "lDZNOqrHI4JSxPM70ARfiIpg0rDsgyHF4To05atzZhpUmmfCzWq5RSJDIIlLkHrO",
+        "monitoring_username": "lDWzf3ickkteAKMoKE6yzYcv9AvNeUfSGW2GPTfuPV99EvDXjhxAUPeGkSQlZGEz",
+        "password": "ca05e71d-f9d6-4743-9f56-9edb3dbdbff7",
+        "protocols": {
+          "amqp": {
+            "host": "10.7.16.22",
+            "password": "ca05e71d-f9d6-4743-9f56-9edb3dbdbff7",
+            "port": 5672,
+            "ssl": false,
+            "uri": "amqp://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5672",
+            "uris": [
+              "amqp://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5672"
+            ],
+            "username": "2e5552dd-94da-4768-aeca-ffb664ebce86",
+            "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+          },
+          "amqps": {
+            "host": "10.7.16.22",
+            "password": "ca05e71d-f9d6-4743-9f56-9edb3dbdbff7",
+            "port": 5671,
+            "ssl": true,
+            "uri": "amqps://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5671",
+            "uris": [
+              "amqps://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5671"
+            ],
+            "username": "2e5552dd-94da-4768-aeca-ffb664ebce86",
+            "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+          },
+          "management": {
+            "host": "10.7.16.22",
+            "password": "ca05e71d-f9d6-4743-9f56-9edb3dbdbff7",
+            "path": "/api",
+            "port": 15672,
+            "ssl": false,
+            "uri": "http://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:15672/api",
+            "uris": [
+              "http://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:15672/api"
+            ],
+            "username": "2e5552dd-94da-4768-aeca-ffb664ebce86"
+          },
+          "management_tls": {
+            "host": "10.7.16.22",
+            "password": "ca05e71d-f9d6-4743-9f56-9edb3dbdbff7",
+            "path": "/api",
+            "port": 15671,
+            "ssl": true,
+            "uri": "https://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:15671/api",
+            "uris": [
+              "https://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:15671/api"
+            ],
+            "username": "2e5552dd-94da-4768-aeca-ffb664ebce86"
+          }
+        },
+        "rmq_port": 5672,
+        "tls_mgmt_port": 15671,
+        "tls_port": 5671,
+        "uri": "amqps://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5671",
+        "uris": [
+          "amqps://2e5552dd-94da-4768-aeca-ffb664ebce86:ca05e71d-f9d6-4743-9f56-9edb3dbdbff7@10.7.16.22:5671"
+        ],
+        "username": "2e5552dd-94da-4768-aeca-ffb664ebce86",
+        "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+      },
+      "instance_guid": "070318e0-bed8-4263-993e-1c3f5e8f1ec4",
+      "instance_name": "rmqsmall",
+      "label": "rabbitmq",
+      "name": "rmqsmall",
+      "plan": "single-node",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "blacksmith",
+        "dedicated",
+        "rabbitmq"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}
+
+
+VCAP_APPLICATION: {
+  "application_id": "00719e0c-dc66-40af-bf8f-90755bf374b0",
+  "application_name": "rabbitmq",
+  "application_uris": [
+    "rabbitmq.run.codex2.starkandwayne.com"
+  ],
+  "cf_api": "https://api.system.codex2.starkandwayne.com",
+  "limits": {
+    "fds": 16384
+  },
+  "name": "rabbitmq",
+  "organization_id": "0b383e89-cae5-4f98-bbd8-7a8a6e1296a0",
+  "organization_name": "system",
+  "space_id": "bacd79a6-9a65-4ffc-8349-b314883efd84",
+  "space_name": "dev",
+  "uris": [
+    "rabbitmq.run.codex2.starkandwayne.com"
+  ],
+  "users": null
+}
+
+
+
+User-Provided:
+RABBITMQ_USE_TLS: true
+
+No running env variables have been set
+
+No staging env variables have been set
+```
+
+Note the `"credential_type": "dynamic"` as well as the uuid based format for both `username` and `password` used for interacting with rabbitmq's service instance
+
+### Service key
+
+`cf service-key rmqsmall rmqappuser` # replace with the service and service key name used
+
+```yaml
+Getting key rmqappuser for service instance rmqsmall as admin...
+
+{
+  "credentials": {
+    "api_url": "https://rabbitmq-single-node-070318e0-bed8-4263-993e-1c3f5e8f1ec4.system.codex2.starkandwayne.com/api",
+    "credential_type": "dynamic",
+    "dashboard_url": "https://rabbitmq-single-node-070318e0-bed8-4263-993e-1c3f5e8f1ec4.system.codex2.starkandwayne.com/#/login/3EfZvJt0QOxtDZCQfcwsVvQqxv58w3S3T7tRIh408e96gCHHBrn7bviYjxzzHUO3/67vg3KdmZ7x79VjVod6yRtXpeQnn19ztGlP6uCNplXLSxGRzpy3mTo4pO9dFnC9g",
+    "host": "10.7.16.22",
+    "hostname": "10.7.16.22",
+    "hostnames": [
+      "10.7.16.22"
+    ],
+    "mgmt_port": 15672,
+    "monitoring_password": "lDZNOqrHI4JSxPM70ARfiIpg0rDsgyHF4To05atzZhpUmmfCzWq5RSJDIIlLkHrO",
+    "monitoring_username": "lDWzf3ickkteAKMoKE6yzYcv9AvNeUfSGW2GPTfuPV99EvDXjhxAUPeGkSQlZGEz",
+    "password": "4335fed9-299f-4c3a-b8dd-ee00dbab9f7a",
+    "protocols": {
+      "amqp": {
+        "host": "10.7.16.22",
+        "password": "4335fed9-299f-4c3a-b8dd-ee00dbab9f7a",
+        "port": 5672,
+        "ssl": false,
+        "uri": "amqp://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5672",
+        "uris": [
+          "amqp://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5672"
+        ],
+        "username": "43eb6b37-dfa7-446d-9317-b4c2030cf777",
+        "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+      },
+      "amqps": {
+        "host": "10.7.16.22",
+        "password": "4335fed9-299f-4c3a-b8dd-ee00dbab9f7a",
+        "port": 5671,
+        "ssl": true,
+        "uri": "amqps://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5671",
+        "uris": [
+          "amqps://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5671"
+        ],
+        "username": "43eb6b37-dfa7-446d-9317-b4c2030cf777",
+        "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+      },
+      "management": {
+        "host": "10.7.16.22",
+        "password": "4335fed9-299f-4c3a-b8dd-ee00dbab9f7a",
+        "path": "/api",
+        "port": 15672,
+        "ssl": false,
+        "uri": "http://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:15672/api",
+        "uris": [
+          "http://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:15672/api"
+        ],
+        "username": "43eb6b37-dfa7-446d-9317-b4c2030cf777"
+      },
+      "management_tls": {
+        "host": "10.7.16.22",
+        "password": "4335fed9-299f-4c3a-b8dd-ee00dbab9f7a",
+        "path": "/api",
+        "port": 15671,
+        "ssl": true,
+        "uri": "https://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:15671/api",
+        "uris": [
+          "https://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:15671/api"
+        ],
+        "username": "43eb6b37-dfa7-446d-9317-b4c2030cf777"
+      }
+    },
+    "rmq_port": 5672,
+    "tls_mgmt_port": 15671,
+    "tls_port": 5671,
+    "uri": "amqps://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5671",
+    "uris": [
+      "amqps://43eb6b37-dfa7-446d-9317-b4c2030cf777:4335fed9-299f-4c3a-b8dd-ee00dbab9f7a@10.7.16.22:5671"
+    ],
+    "username": "43eb6b37-dfa7-446d-9317-b4c2030cf777",
+    "vhost": "070318e0-bed8-4263-993e-1c3f5e8f1ec4"
+  }
+}
+```
+
+Again, note the `"credential_type": "dynamic"` as well as the uuid based format for both `username` and `password` used for interacting with rabbitmq's service instance.
+
+### Rabbitmq instance
+
+Each of those , `bind` and `service-key` commands has created the corresponding key to rabbitmq's instance. ssh to the rabbitmq instance ( discussed on [permissions](#permissions) earlier ) and list the users:
+
+`rabbitmqctl list_users`
+
+```json
+Listing users ...
+user    tags
+UAmJaQMHpT3NEgF0hHRu3ztIhSq9BhrG1ffcNg86aruy54qBy5hNm799aKqalWqm        [management policymaker]
+43eb6b37-dfa7-446d-9317-b4c2030cf777    [management, policymaker]
+2e5552dd-94da-4768-aeca-ffb664ebce86    [management, policymaker]
+lDWzf3ickkteAKMoKE6yzYcv9AvNeUfSGW2GPTfuPV99EvDXjhxAUPeGkSQlZGEz        [monitoring]
+3EfZvJt0QOxtDZCQfcwsVvQqxv58w3S3T7tRIh408e96gCHHBrn7bviYjxzzHUO3        [administrator]
+```
+
+Note the uuid based format for each of the users created earlier, `2e5552dd-94da-4768-aeca-ffb664ebce86` for the binding and `43eb6b37-dfa7-446d-9317-b4c2030cf777` for the service key
+
+### Deleting the dynamic credentials
+
+* unbind the application
+
+`cf unbind-service rabbitmq rmqsmall`
+
+```
+Unbinding app rabbitmq from service rmqsmall in org system / space dev as admin...
+OK
+```
+
+* delete the service key
+
+`cf delete-service-key rmqsmall rmqappuser`
+
+```
+cf delete-service-key rmqsmall rmqappuser
+Really delete the service key rmqappuser? [yN]: y
+Deleting key rmqappuser for service instance rmqsmall as admin...
+OK
+```
+
+### Confirming cleanup
+
+Repeat the `list_users` command issued earlier on the rabbitmq instance
+
+`rabbitmqctl list_users`
+
+```
+Listing users ...
+user    tags
+UAmJaQMHpT3NEgF0hHRu3ztIhSq9BhrG1ffcNg86aruy54qBy5hNm799aKqalWqm        [management policymaker]
+lDWzf3ickkteAKMoKE6yzYcv9AvNeUfSGW2GPTfuPV99EvDXjhxAUPeGkSQlZGEz        [monitoring]
+3EfZvJt0QOxtDZCQfcwsVvQqxv58w3S3T7tRIh408e96gCHHBrn7bviYjxzzHUO3        [administrator]
+```
+
+and confirm that the uuid based users are no longer present.
 
 ## Conclusion
 


### PR DESCRIPTION
# Features

* RabbitMQ Dynamic Credentials 

The dynamic credentials feature extends the predefined static credentials with new, unique credentials created each time an application is bound to the RabbitMQ service or a service key is created against that same service. As a result, operators can rely on the static credentials for monitoring, application testing and administering the RabbitMQ service while relying on dynamic credentials for each of the application bindings or service keys created.

# Bugs

* Remove failing bosh cleanup - relying on external bosh director 

# Documentation

* Update rabbitmq-walkthrough with dynamic credentials testing