### PR TITLE
reinstate persistent_disk

### DIFF
--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -28,7 +28,7 @@ instance_groups:
     stemcell:  bionic
     azs:             (( grab params.availability_zones || meta.default.azs ))
     vm_type:         (( grab params.vm_type   || "blacksmith" ))
-    disk_type:       (( grab params.disk_type || "blacksmith" ))
+    persistent_disk: (( grab params.disk_size || 20480 ))
     networks:
       - name:       (( grab params.network || "blacksmith" ))
         static_ips: [(( grab params.ip ))]


### PR DESCRIPTION
Using `disk_type`  instead of  `persistent_disk` although allows the selection of the disk size from cloud config, it doesn't declare the required attribute of the [persistent](https://bosh.io/docs/persistent-disks/) nature of the disk. As a result, the root volume is used for the predefined `/var/vcap/store` which is meant to be mounted to the [persistent disk](https://bosh.io/docs/persistent-disks/#accessing-persistent-disk) leading it in that way to run out of space.:

```
Filesystem      Size  Used Avail Use% Mounted on
udev            967M     0  967M   0% /dev
tmpfs           199M   27M  172M  14% /run
/dev/sda1       2.9G  2.8G     0 100% /
tmpfs           992M     0  992M   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           992M     0  992M   0% /sys/fs/cgroup
/dev/sdb2       7.9G  649M  6.8G   9% /var/vcap/data
tmpfs            16M  268K   16M   2% /var/vcap/data/sys/run
tmpfs           199M     0  199M   0% /run/user/1004
```

reinstating `persistent_disk` adds an additional volume which is rightfully mounted under `/var/vcap/store`. This time around the root `/` volume remains at reasonable usage level. This is easier to be noticed on vmare's CPI where the root volume is 3GB. :

```
blacksmith/472f82be-26a3-4d47-b855-3a2bf62d56b9:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            967M     0  967M   0% /dev
tmpfs           199M  6.3M  193M   4% /run
/dev/sda1       2.9G  1.7G  1.2G  60% /
tmpfs           992M     0  992M   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           992M     0  992M   0% /sys/fs/cgroup
/dev/sdb2       7.9G  639M  6.8G   9% /var/vcap/data
tmpfs            16M  268K   16M   2% /var/vcap/data/sys/run
/dev/sdc1        20G  1.3G   18G   7% /var/vcap/store
tmpfs           199M     0  199M   0% /run/user/1002
```