### PR TITLE
Nats tls only

### DIFF
--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -37,6 +37,8 @@ instance_groups:
       environment: (( grab meta.environment ))
       bosh_env: (( grab meta.bosh_env ))
       plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
+      cf:
+        nats_tls_only: (( grab params.cf.nats_tls_only || false ))
       service:
         id:          (( grab params.rabbitmq_service_id          || "rabbitmq" ))
         name:        (( grab params.rabbitmq_service_name        || params.rabbitmq_service_id || "rabbitmq" ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -38,7 +38,7 @@ instance_groups:
       bosh_env: (( grab meta.bosh_env ))
       plans: (( grab params.rabbitmq_plans || meta.default.rabbitmq_plans ))
       cf:
-        nats_tls_only: (( grab params.cf.nats_tls_only || false ))
+        nats_tls_only: (( grab params.cf.nats_tls_only || true ))
       service:
         id:          (( grab params.rabbitmq_service_id          || "rabbitmq" ))
         name:        (( grab params.rabbitmq_service_name        || params.rabbitmq_service_id || "rabbitmq" ))


### PR DESCRIPTION
[Features]

* Adds and passes nats_tls_only as a parameter to rabbitmq so that it
can communicate with a cf-deployment from v17.0.0 onwards 