### PR TITLE
Add service type to the redis plan

### DIFF
--- a/manifests/forges/redis.yml
+++ b/manifests/forges/redis.yml
@@ -50,3 +50,4 @@ instance_groups:
         description: (( grab params.redis_service_description || "A dedicated Redis instance, deployed on-demand" ))
         tags:        (( grab params.redis_service_tags        || meta.default.redis_tags ))
         limit:       (( grab params.redis_service_limit       || 0 ))
+        type:        (( grab params.redis_service_type        || "standalone" ))


### PR DESCRIPTION
This fix is related to a [blacksmith commit](https://github.com/blacksmith-community/redis-forge-boshrelease/pull/31) that would allow for Redis to use a hostname binding instead of an ip binding. Without this commit, the bosh dns address that would be returned by `params.hostname` is missing the plan designator https://github.com/blacksmith-community/blacksmith/blob/master/manifest.go#L158

