### PR TITLE
Revert disk type back to persistent

### DIFF
--- a/manifests/blacksmith/blacksmith.yml
+++ b/manifests/blacksmith/blacksmith.yml
@@ -28,7 +28,7 @@ instance_groups:
     stemcell:  default
     azs:             (( grab params.availability_zones || meta.default.azs ))
     vm_type:         (( grab params.vm_type   || "blacksmith" ))
-    disk_type:       (( grab params.disk_type || "blacksmith" ))
+    persistent_disk: (( grab params.disk_size || 20480 ))
     networks:
       - name:       (( grab params.network || "blacksmith" ))
         static_ips: [(( grab params.ip ))]


### PR DESCRIPTION
The disk type was changed from `persistent_disk` to `disk_type` in kit v0.13.0 which would cause the Blacksmith data to disappear on upgrades.  Changing back to `persistent_disk`