### PR TITLE
 Update RabbitMQ Auto-scaling Configuration and BOSH Release Version

### DIFF
--- a/manifests/forges/rabbitmq-autoscale.yml
+++ b/manifests/forges/rabbitmq-autoscale.yml
@@ -33,6 +33,11 @@ instance_groups:
           agent:
             cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
             key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
+      cloud-controller:
+        tls:
+          ca_cert: (( vault meta.cf.exodus_path ":cloud_controller_tls_ca" ))
+          cert: (( vault meta.cf.exodus_path ":cloud_controller_tls_certificate" ))
+          key: (( vault meta.cf.exodus_path ":cloud_controller_tls_private_key" ))
       rabbitmq_metrics_emitter:
         cloud_foundry:
           api:    (( grab meta.cf.api_url ))

--- a/manifests/forges/rabbitmq-autoscale.yml
+++ b/manifests/forges/rabbitmq-autoscale.yml
@@ -33,11 +33,21 @@ instance_groups:
           agent:
             cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
             key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
-      cloud-controller:
+      syslog_agent_api:
         tls:
-          ca_cert: (( vault meta.cf.exodus_path ":cloud_controller_tls_ca" ))
-          cert: (( vault meta.cf.exodus_path ":cloud_controller_tls_certificate" ))
-          key: (( vault meta.cf.exodus_path ":cloud_controller_tls_private_key" ))
+          ca_cert: (( vault meta.cf.exodus_path ":syslog_agent_api_tls_ca" ))
+          cert: (( vault meta.cf.exodus_path ":syslog_agent_api_tls_certificate" ))
+          key: (( vault meta.cf.exodus_path ":syslog_agent_api_tls_private_key" ))
+      syslog_agent_metrics:
+        tls:
+          ca_cert: (( vault meta.cf.exodus_path ":syslog_agent_metrics_tls_ca" ))
+          cert: (( vault meta.cf.exodus_path ":syslog_agent_metrics_tls_certificate" ))
+          key: (( vault meta.cf.exodus_path ":syslog_agent_metrics_tls_private_key" ))
+      forwarder_agent_metrics:
+        tls:
+          ca_cert: (( vault meta.cf.exodus_path ":forwarder_agent_metrics_tls_ca" ))
+          cert: (( vault meta.cf.exodus_path ":forwarder_agent_metrics_tls_certificate" ))
+          key: (( vault meta.cf.exodus_path ":forwarder_agent_metrics_tls_private_key" ))
       rabbitmq_metrics_emitter:
         cloud_foundry:
           api:    (( grab meta.cf.api_url ))

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -18,7 +18,7 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 1.2.4+dev.23
+  version: 1.2.5+dev.5
 #  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v1.2.4/rabbitmq-forge-1.2.4.tgz
 #  sha1:    539bf9fce41657f6d0bd549e4b5bed9d3232c96f
 

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -18,9 +18,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 1.2.5
-  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v1.2.5/rabbitmq-forge-1.2.5.tgz
-  sha1:    03fa361a9f63fdf92f1e3cf0fcbac7b8c2770dcf
+  version: 1.2.4+dev.23
+#  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v1.2.4/rabbitmq-forge-1.2.4.tgz
+#  sha1:    539bf9fce41657f6d0bd549e4b5bed9d3232c96f
 
 params:
   releases:

--- a/manifests/forges/rabbitmq.yml
+++ b/manifests/forges/rabbitmq.yml
@@ -18,9 +18,9 @@ meta:
 
 releases:
 - name:    rabbitmq-forge
-  version: 1.2.5+dev.5
-#  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v1.2.4/rabbitmq-forge-1.2.4.tgz
-#  sha1:    539bf9fce41657f6d0bd549e4b5bed9d3232c96f
+  version: 1.2.7
+  url:     https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/releases/download/v1.2.7/rabbitmq-forge-1.2.7.tgz
+  sha1:    845e9930b891098336aa54ceea3044085c8cb008
 
 params:
   releases:


### PR DESCRIPTION
**Description**:

This PR introduces the following changes to enhance RabbitMQ auto-scaling and update BOSH release configurations:

1. **Added TLS configuration** for `syslog_agent_api`, `syslog_agent_metrics`, and `forwarder_agent_metrics` in `manifests/forges/rabbitmq-autoscale.yml`:
    - Added new certificates and keys for secure communication.

2. **Updated RabbitMQ BOSH Release** in `manifests/forges/rabbitmq.yml`:
    - Upgraded from version `1.2.5` to `1.2.7`.
    - Updated the download URL and SHA1 checksum accordingly.

**Reason for the update**:
- The TLS configurations are required for enhanced security when emitting metrics and logs.
- The RabbitMQ BOSH release version update includes important bug fixes and optimizations.
