### PR TITLE
Add Valkey service support

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -468,6 +468,71 @@ Blacksmith uses "forges" to deploy different types of services. You can activate
   - `redis-dual-mode` - When enabled along with `redis-tls`, allows both
     TLS and non-TLS communication.
 
+#### Valkey
+
+- `valkey` (Blacksmith Forge) - Enables the Blacksmith Service
+  Broker to deploy Valkey key-value instances. Valkey is a Redis-compatible
+  open-source key-value store supporting versions 7, 8, and 9.
+
+  Activating this feature also activates the following parameters:
+
+  - `valkey_plans` - A YAML fragment that contains the set of
+     Cloud Foundry Valkey service plans to offer. Supports both
+     standalone and cluster deployment types.
+
+  - `valkey_service_name` - The name of the service, to be
+    shown in the services marketplace.
+
+    Defaults to `valkey`.
+
+  - `valkey_service_id` - A globally unique (internal)
+    identifier for this service.
+
+    Defaults to `valkey`.
+
+  - `valkey_service_description` - A long-form description of
+    the service, for use in both console and web-based UIs.
+
+    Defaults to `A dedicated Valkey instance, deployed
+    on-demand.`
+
+  - `valkey_service_tags` - The list of tags to apply to all
+    new instances of this service.
+
+    Defaults to `blacksmith`, `valkey`, `dedicated` and `redis`. If
+    you specify this, and you want the defaults too, you have to
+    provide them explicitly.
+
+  - `valkey_service_limit` - An upper limit on the number of
+    service instances _total_ that can be provisioned, regardless
+    of per-plan limits. `0` (the default) imposes no global
+    limit.
+
+  Example configuration:
+  ```yaml
+  valkey_plans:
+    standalone-9:
+      name: standalone-9
+      description: A dedicated Valkey 9 server
+      type: standalone-9
+      vm_type: default
+      limit: 10
+      
+    cluster-9:
+      name: cluster-9
+      description: A Valkey 9 cluster with 3 masters and 3 replicas
+      type: cluster-9
+      vm_type: default
+      limit: 5
+  ```
+
+  Additional Valkey features:
+
+  - `valkey-tls` - Enables TLS encryption for Valkey communications.
+
+  - `valkey-dual-mode` - When enabled along with `valkey-tls`, allows both
+    TLS and non-TLS communication.
+
 #### MariaDB
 
 - `mariadb` (Blacksmith Forge) - Enables the Blacksmith Service

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Blacksmith is an on-demand service broker that uses BOSH to provision dedicated 
   - PostgreSQL databases
   - RabbitMQ message brokers (with TLS, clustering, and autoscaling)
   - Redis key-value stores (with persistence and TLS)
+  - Valkey key-value stores (with persistence and TLS)
   - MariaDB databases
   - Kubernetes clusters
 - **Security Features**: TLS support, credential management, and role-based access control
@@ -84,7 +85,12 @@ Blacksmith provides "forges" that know how to deploy specific data services:
 - See [rabbitmq-walkthrough.md](rabbitmq-walkthrough.md) for details
 
 ### Redis
-- Standalone instances with optional persistence
+- Standalone and clustered depployments with optional persistence
+- TLS encryption for secure communication
+- Cache and data store configurations
+
+### Valkey
+- Standalone and clustered depployments with optional persistence
 - TLS encryption for secure communication
 - Cache and data store configurations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the Blacksmith Genesis Kit documentation. This directory contains det
   - [PostgreSQL](forges/postgresql.md)
   - [RabbitMQ](forges/rabbitmq.md)
   - [Redis](forges/redis.md)
+  - [Valkey](forges/valkey.md)
   - [MariaDB](forges/mariadb.md)
   - [Kubernetes](forges/kubernetes.md)
 - [Addons](addons.md) - Using Blacksmith addons

--- a/docs/forges/README.md
+++ b/docs/forges/README.md
@@ -6,11 +6,11 @@ Blacksmith uses "forges" to deploy different types of services. Each forge conta
 
 Blacksmith currently supports the following service forges:
 
-- [PostgreSQL](postgresql.md) - PostgreSQL database services (standalone and clustered)
-- [RabbitMQ](rabbitmq.md) - RabbitMQ message broker services (with TLS, clustering, and autoscaling)
-- [Redis](redis.md) - Redis key-value store services (persistent and cache modes)
-- [MariaDB](mariadb.md) - MariaDB/MySQL database services
-- [Kubernetes](kubernetes.md) - Kubernetes container orchestration clusters
+- PostgreSQL - PostgreSQL database services (standalone and clustered)
+- RabbitMQ - RabbitMQ message broker services (with TLS, clustering, and autoscaling)
+- Redis - Redis key-value store services (persistent and cache modes)
+- Valkey- Valkey key-value store services (Redis-compatible, versions 7/8/9)
+- MariaDB - MariaDB/MySQL database services
 
 ## Forge Configuration 
 
@@ -23,7 +23,7 @@ All forges follow a similar configuration pattern:
 ```yaml
 kit:
   features:
-    - forge-name  # E.g., postgresql, rabbitmq, redis, etc.
+    - forge-name  # E.g., postgresql, rabbitmq, redis, valkey, etc.
 
 params:
   forge_service_name: "service-name"          # Name in the marketplace
@@ -78,6 +78,10 @@ Some forges have additional feature flags that enable special capabilities:
 - **Redis**:
   - `redis-tls` - Enable TLS encryption
   - `redis-dual-mode` - Allow both TLS and non-TLS connections
+
+- **Valkey**:
+  - `valkey-tls` - Enable TLS encryption
+  - `valkey-dual-mode` - Allow both TLS and non-TLS connections
 
 ## Using Service Instances
 

--- a/docs/forges/valkey.md
+++ b/docs/forges/valkey.md
@@ -1,0 +1,356 @@
+# Valkey Forge
+
+The Valkey forge provides on-demand Valkey key-value store instances. Valkey is a Redis-compatible, open-source key-value store that supports multiple versions and deployment modes.
+
+## Features
+
+- **Multiple Versions**: Support for Valkey 7, 8, and 9
+- **Standalone Mode**: Single-node deployment for development and small workloads
+- **Cluster Mode**: Multi-node clusters with automatic sharding and replication
+- **TLS Support**: Optional TLS encryption for data in transit
+- **Dual-Mode TLS**: Support for both TLS and non-TLS connections simultaneously
+- **Persistence**: Configurable RDB and AOF persistence options
+- **Resource Control**: Configurable memory limits and eviction policies
+
+## Basic Configuration
+
+To enable the Valkey forge, add it to your kit features:
+
+```yaml
+kit:
+  features:
+    - valkey
+```
+
+## Service Plans
+
+The forge provides default plans for both standalone and cluster deployments across all supported versions:
+
+### Standalone Plans
+
+- `standalone-7`: Valkey 7.x single-node instance
+- `standalone-8`: Valkey 8.x single-node instance  
+- `standalone-9`: Valkey 9.x single-node instance
+
+### Cluster Plans
+
+- `cluster-7`: Valkey 7.x cluster (3 masters + 3 replicas)
+- `cluster-8`: Valkey 8.x cluster (3 masters + 3 replicas)
+- `cluster-9`: Valkey 9.x cluster (3 masters + 3 replicas)
+
+## Configuration Parameters
+
+### Service Configuration
+
+```yaml
+params:
+  valkey_service_id: "valkey"
+  valkey_service_name: "valkey"
+  valkey_service_description: "A dedicated Valkey instance, deployed on-demand"
+  valkey_service_tags:
+    - blacksmith
+    - dedicated
+    - valkey
+    - redis
+  valkey_service_limit: 0  # 0 = unlimited
+```
+
+**Important**
+
+Cloudfoundry applications utilize service tags to enable the service binding. Before creating the service instance make sure that you set the correct tags for your application to take advantage of the service binding.
+
+### Custom Plans
+
+You can customize plans or create new ones:
+
+```yaml
+params:
+  valkey_plans:
+    standalone-9:
+      name: standalone-9
+      description: A dedicated Valkey 9 server, with no redundancy or replication
+      limit: 7
+      type: standalone-9
+      vm_type: default
+    
+    cluster-9:
+      name: cluster-9
+      description: A Valkey 9 cluster with 3 master nodes and 3 replica nodes
+      limit: 5
+      type: cluster-9
+      vm_type: default
+      
+    custom-large:
+      name: custom-large
+      description: Large Valkey 9 instance with extra memory
+      limit: 3
+      type: standalone-9
+      vm_type: large
+```
+
+## TLS Configuration
+
+### Enable TLS
+
+To enable TLS for all Valkey connections:
+
+```yaml
+kit:
+  features:
+    - valkey
+    - valkey-tls
+
+# TLS certificates will be stored in Vault at:
+# (( vault meta.vault "/tls/ca:certificate" ))
+# (( vault meta.vault "/tls/ca:key" ))
+```
+
+### Dual-Mode TLS
+
+To support both TLS and non-TLS connections:
+
+```yaml
+kit:
+  features:
+    - valkey
+    - valkey-dual-mode
+```
+
+## Plan Types
+
+### Standalone Plans
+
+Standalone plans deploy a single Valkey instance. Best for:
+- Development and testing
+- Low-traffic applications
+- Caching layers where data loss is acceptable
+
+### Cluster Plans
+
+Cluster plans deploy a multi-node Valkey cluster with automatic sharding and replication. Best for:
+- Production workloads requiring high availability
+- Large datasets that need horizontal scaling
+- Applications requiring fault tolerance
+
+## Version Selection
+
+Choose the Valkey version based on your requirements:
+
+- **Valkey 7**: Stable, Redis 7.x compatible
+- **Valkey 8**: Latest stable with new features, Redis 7.x+ compatible
+- **Valkey 9**: Latest version with advanced features, Redis 7.x+ compatible
+
+## Connection Information
+
+After provisioning a Valkey instance, connection credentials are provided via service binding:
+
+```json
+VCAP_SERVICES: {
+  "valkey": [
+    {
+      "binding_guid": "99a7fd19-376d-42eb-bd7b-f0c4a77a63de",
+      "binding_name": null,
+      "credentials": {
+        "host": "65d620db-590a-4060-a41f-d40fe6dfcad8.standalone.ocfp-aws-lab-ocf-us-east-1-cf-net-ocf.valkey-standalone-8-d618ff1d-6b50-403e-9d11-2f9d6c0ae72b.bosh",
+        "password": "E1bOo1bwUK18Bo0kM7xj9eiVVgPe3mgsvPmyQxCt70nRIIw9Xz1UcP7KtFJ1HGf4",
+        "port": 6379,
+        "tls_port": 16379,
+        "tls_versions": [
+          "tlsv1.2",
+          "tlsv1.3"
+        ]
+      },
+      "instance_guid": "d618ff1d-6b50-403e-9d11-2f9d6c0ae72b",
+      "instance_name": "valkeys8",
+      "label": "valkey",
+      "name": "valkeys8",
+      "plan": "standalone-8",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "blacksmith",
+        "dedicated",
+        "valkey",
+        "redis"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}
+```
+
+For clusters, additional fields are provided:
+
+```json
+VCAP_SERVICES: {
+  "valkey": [
+    {
+      "binding_guid": "cc451ee5-6adc-4f67-af61-7d37daad6f8a",
+      "binding_name": null,
+      "credentials": {
+        "host": "48f45726-df6f-4274-b8b7-3f846e30bd15.node.ocfp-aws-lab-ocf-us-east-1-cf-net-ocf.valkey-cluster-8-470fb7bb-1726-4471-a143-470dc1c01e6d.bosh",
+        "hosts": [
+          "10.0.2.41",
+          "10.0.2.103",
+          "10.0.2.159",
+          "10.0.2.42",
+          "10.0.2.104",
+          "10.0.2.160"
+        ],
+        "password": "Ir58iCwfr2NGEhYN2x3DBgAutKGUoQ7x2bprYx9ZjZ9H2gX6iqssogQ5BfNDv9bg",
+        "port": 6379,
+        "tls_port": 16379,
+        "tls_versions": [
+          "tlsv1.2",
+          "tlsv1.3"
+        ]
+      },
+      "instance_guid": "470fb7bb-1726-4471-a143-470dc1c01e6d",
+      "instance_name": "valkeyc8",
+      "label": "valkey",
+      "name": "valkeyc8",
+      "plan": "cluster-8",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "blacksmith",
+        "dedicated",
+        "valkey",
+        "redis"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}
+```
+
+## Example Environment
+
+Complete example for a production Valkey deployment:
+
+```yaml
+---
+kit:
+  name: blacksmith
+  version: latest
+  features:
+    - ocfp
+    - valkey
+    - valkey-dual-mode
+
+genesis:
+  env: ocfp-aws-lab-ocf-us-east-1
+
+meta:
+  azs:
+    - (( concat genesis.env "-z1" ))
+    - (( concat genesis.env "-z2" ))
+    - (( concat genesis.env "-z3" ))
+  valkey_plan:
+    network: (( concat genesis.env "-cf-net-ocf" ))
+    azs: (( grab meta.azs ))
+    persist: true
+
+params:
+  blacksmith:
+    
+
+  # Valkey service configuration
+  valkey_service_name: "valkey"
+  valkey_service_description: "High-performance Valkey key-value store"
+  valkey_service_limit: 50
+  
+  valkey_plans:
+    standalone-7:
+      name: standalone-7
+      description: A dedicated Valkey 7 server, with no redundancy or replication
+      limit: 7
+      type: standalone-7
+      vm_type: redis-small
+      .: (( inject meta.valkey_plan ))
+    standalone-8:
+      name: standalone-8
+      description: A dedicated Valkey 8 server, with no redundancy or replication
+      limit: 7
+      type: standalone-8
+      vm_type: redis-small
+      .: (( inject meta.valkey_plan ))
+    standalone-9:
+      name: standalone-9
+      description: A dedicated Valkey 9 server, with no redundancy or replication
+      limit: 7
+      type: standalone-9
+      vm_type: redis-small
+      .: (( inject meta.valkey_plan ))
+    cluster-7:
+      name: cluster-7
+      description: A Valkey 7 cluster with 3 master nodes and 3 replica nodes
+      limit: 5
+      type: cluster-7
+      vm_type: redis-small
+      masters: 3
+      replicas: 1
+      .: (( inject meta.valkey_plan ))
+    cluster-8:
+      name: cluster-8
+      description: A Valkey 8 cluster with 3 master nodes and 3 replica nodes
+      limit: 5
+      type: cluster-8
+      vm_type: redis-small
+      masters: 3
+      replicas: 1
+      .: (( inject meta.valkey_plan ))
+    cluster-9:
+      name: cluster-9
+      description: A Valkey 9 cluster with 3 master nodes and 3 replica nodes
+      limit: 5
+      type: cluster-9
+      vm_type: redis-small
+      masters: 3
+      replicas: 1
+      .: (( inject meta.valkey_plan ))
+```
+
+## Best Practices
+
+1. **Use Clusters for Production**: Always use cluster plans for production workloads requiring high availability
+2. **Enable TLS**: Use `valkey-tls` feature for production deployments
+3. **Set Appropriate Limits**: Configure per-plan and global limits to prevent resource exhaustion
+4. **Choose the Right VM Type**: Size VMs appropriately based on expected memory and CPU needs
+5. **Monitor Resource Usage**: Track memory usage and connection counts
+6. **Regular Backups**: Enable SHIELD backups for persistent data
+7. **Version Testing**: Test application compatibility when upgrading Valkey versions
+
+## Troubleshooting
+
+### Connection Issues
+
+If applications cannot connect to Valkey:
+
+1. Verify security groups allow traffic on port 6379 (or 16379 for TLS)
+2. Check service binding credentials are correctly injected
+3. Verify TLS configuration matches between client and server
+
+### Memory Issues
+
+If Valkey instances run out of memory:
+
+1. Check current memory usage via Valkey CLI
+2. Review eviction policies
+3. Consider upgrading to larger VM types
+4. Enable RDB/AOF persistence to disk if appropriate
+
+### Cluster Split-Brain
+
+In rare cases, cluster nodes may become partitioned:
+
+1. Check network connectivity between nodes
+2. Review BOSH instance health
+3. Use Valkey cluster repair commands if needed
+4. Consider reprovisioning the service instance
+
+## Related Documentation
+
+- [Blacksmith Architecture](../architecture.md)
+- [Forge Configuration](README.md)
+- [Troubleshooting Guide](../troubleshooting.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ During environment creation, you'll be prompted for:
 - Environment name
 - IaaS provider (vsphere, aws, azure, google, openstack, stackit, or external-bosh)
 - IaaS-specific credentials and configuration
-- Service forges to enable (postgresql, rabbitmq, redis, mariadb, kubernetes)
+- Service forges to enable (postgresql, rabbitmq, redis, valkey, mariadb, kubernetes)
 - Static IP for the Blacksmith broker
 - Additional features (TLS, SHIELD backups, etc.)
 

--- a/docs/walkthroughs/README.md
+++ b/docs/walkthroughs/README.md
@@ -53,6 +53,11 @@ Select the walkthrough that matches your target infrastructure:
 - For **Google Cloud**: Follow [Google Cloud Deployment](google-deployment.md)
 - For **vSphere**: Refer to examples in the [main manual](../MANUAL.md)
 
+## Migration Guides
+
+- [Redis to Valkey Standalone](valkey-standalone-migration.md) - Migrate from Redis to Valkey standalone using live replication
+- [Redis Cluster to Valkey Cluster](valkey-cluster-migration.md) - Migrate from Redis cluster to Valkey cluster using RedisShake
+
 ## Additional Resources
 
 After completing the basic deployment, you may want to explore:

--- a/docs/walkthroughs/valkey-cluster-migration.md
+++ b/docs/walkthroughs/valkey-cluster-migration.md
@@ -13,7 +13,7 @@ automatically, syncing data from all source masters to the destination.
 ## Prerequisites
 
 - CF CLI authenticated with space developer permissions
-- `redis-cli` available (installed on the jumpbox or BOSH VMs)
+- `redis-cli` with TLS support (see [TLS-Enabled redis-cli](#tls-enabled-redis-cli) below)
 - [RedisShake v4.5.0+](https://github.com/tair-opensource/RedisShake/releases)
   installed on the jumpbox
 - A healthy Redis cluster service instance with data to migrate
@@ -28,6 +28,28 @@ tar xzf redis-shake.tar.gz
 cp redis-shake-v4.5.0-linux-amd64/redis-shake .
 ./redis-shake -v
 ```
+
+## TLS-Enabled redis-cli
+
+When the `redis-tls` feature is enabled, the Blacksmith-packaged `redis-cli`
+(toolbelt-redis) is compiled without TLS support. You need to build a
+TLS-capable `redis-cli` on the jumpbox to interact with TLS-enabled clusters.
+
+```bash
+sudo apt-get install -y build-essential libssl-dev pkg-config
+curl -sL https://download.redis.io/releases/redis-7.2.3.tar.gz | tar xz
+cd redis-7.2.3
+make BUILD_TLS=yes
+sudo cp src/redis-cli /usr/local/bin/redis-cli
+redis-cli -v
+```
+
+All `redis-cli` commands in this guide assume TLS is enabled. Add `--tls
+--insecure` to every command, or use `--tls --cacert <path>` if you have
+the CA certificate available.
+
+For `redis-dual-mode` deployments where both plain and TLS ports are active,
+TLS flags are only required when connecting to the TLS port (16379).
 
 ## Create Services
 
@@ -188,6 +210,23 @@ If the `CLUSTER MEET` command in the post-deploy script uses port 6379,
 the cluster will try bus port 16379 (6379 + 10000) instead of 26379,
 causing nodes to never discover each other. The fix is to use the TLS
 port (16379) in the CLUSTER MEET command when TLS dual-mode is enabled.
+
+### redis-cli Returns No Output
+
+If `redis-cli` connects but returns no output and no error, the cluster
+likely has TLS enabled. The client sends plain-text but the server expects
+a TLS handshake, silently dropping the connection.
+
+Add `--tls --insecure` to your commands:
+
+```bash
+redis-cli -h $HOST -p $PORT -a "$PASS" --tls --insecure cluster info
+```
+
+If your `redis-cli` does not support `--tls` (e.g. `Unrecognized option`),
+it was compiled without TLS support. See
+[TLS-Enabled redis-cli](#tls-enabled-redis-cli) above to build a
+TLS-capable version.
 
 ### Cluster Health Issues
 

--- a/docs/walkthroughs/valkey-cluster-migration.md
+++ b/docs/walkthroughs/valkey-cluster-migration.md
@@ -1,0 +1,203 @@
+# Migrating from Redis Cluster to Valkey Cluster
+
+This guide walks through migrating data from a Blacksmith-managed Redis
+cluster to a Valkey cluster using
+[RedisShake](https://github.com/tair-opensource/RedisShake) for
+cluster-to-cluster data migration.
+
+Unlike standalone instances, Redis/Valkey clusters cannot use `REPLICAOF`
+for live replication across clusters, and `redis-cli --cluster import`
+does not support cluster sources. RedisShake handles cluster topology
+automatically, syncing data from all source masters to the destination.
+
+## Prerequisites
+
+- CF CLI authenticated with space developer permissions
+- `redis-cli` available (installed on the jumpbox or BOSH VMs)
+- [RedisShake v4.5.0+](https://github.com/tair-opensource/RedisShake/releases)
+  installed on the jumpbox
+- A healthy Redis cluster service instance with data to migrate
+- A healthy Valkey cluster service instance provisioned via Blacksmith
+
+## Install RedisShake
+
+```bash
+curl -L -o redis-shake.tar.gz \
+  https://github.com/tair-opensource/RedisShake/releases/download/v4.5.0/redis-shake-v4.5.0-linux-amd64.tar.gz
+tar xzf redis-shake.tar.gz
+cp redis-shake-v4.5.0-linux-amd64/redis-shake .
+./redis-shake -v
+```
+
+## Create Services
+
+```bash
+cf cs redis cache-cluster-small redis-cluster-test
+cf cs valkey cluster-8 valkey-cluster-test
+```
+
+## Populate Source Cluster with Test Data
+
+Use `redis-cli -c` (cluster mode) to write test data directly. The `-c`
+flag handles `MOVED` redirects automatically, ensuring keys land on the
+correct master regardless of slot assignment.
+
+```bash
+# Get credentials from the service key
+cf create-service-key redis-cluster-test redis-cluster-key
+cf service-key redis-cluster-test redis-cluster-key
+
+export REDIS_HOST=<redis-host-ip>
+export REDIS_PORT=6379
+export REDIS_PASS=<redis-password>
+
+# Write test data (use -c for cluster mode)
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" SET foo bar
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" SET hello world
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" SET number 42
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" SET name redis
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" SET language cloudfoundry
+```
+
+## Verify Data Before Migration
+
+```bash
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" GET foo
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" GET hello
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" GET number
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" GET name
+redis-cli -c -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" GET language
+```
+
+> **Note:** The `cf-redis-example-app` from pivotal-cf uses a single-node
+> Redis client (`Redis.new`) which does not handle cluster `MOVED` redirects.
+> Keys that hash to a different master's slot range will return
+> `Internal Server Error`. Use `redis-cli -c` for cluster testing instead.
+
+## Get Valkey Service Credentials
+
+```bash
+cf create-service-key valkey-cluster-test valkey-cluster-key
+cf service-key valkey-cluster-test valkey-cluster-key
+
+export VALKEY_HOST=<valkey-host-ip>
+export VALKEY_PORT=6379
+export VALKEY_PASS=<valkey-password>
+```
+
+## Verify Cluster Health
+
+Confirm both clusters are healthy before proceeding.
+
+```bash
+redis-cli -h $REDIS_HOST -p $REDIS_PORT -a "$REDIS_PASS" cluster info
+redis-cli -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" cluster info
+```
+
+Both should show `cluster_state:ok` with all 16384 slots assigned.
+
+## Migrate Data with RedisShake
+
+Create a `shake.toml` configuration file. RedisShake only needs one node
+address per cluster — it discovers the full topology automatically.
+
+```bash
+cat > shake.toml << EOF
+[sync_reader]
+cluster = true
+address = "$REDIS_HOST:$REDIS_PORT"
+password = "$REDIS_PASS"
+tls = false
+sync_rdb = true
+sync_aof = false
+
+[redis_writer]
+cluster = true
+address = "$VALKEY_HOST:$VALKEY_PORT"
+password = "$VALKEY_PASS"
+tls = false
+
+[advanced]
+rdb_restore_command_behavior = "rewrite"
+EOF
+```
+
+## Stop the application
+
+At this point we are ready to migrate the data from the redis cluster to the valkey cluster. Before you do you have to stop the aplication so that no new data gets introduced until the migration is complete.
+
+
+
+## Run the migration:
+
+```bash
+./redis-shake shake.toml
+```
+
+- `sync_rdb = true` — performs full data sync via RDB snapshot
+- `sync_aof = false` — skips incremental replication (one-time copy)
+- `rdb_restore_command_behavior = "rewrite"` — overwrites existing keys
+
+## Verify Data on Valkey
+
+```bash
+redis-cli -c -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" GET foo
+redis-cli -c -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" GET hello
+redis-cli -c -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" GET number
+redis-cli -c -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" GET name
+redis-cli -c -h $VALKEY_HOST -p $VALKEY_PORT -a "$VALKEY_PASS" GET language
+```
+
+## Unbind/Bind redis to valkey
+
+With the data confirmed you are ready to unbind the redis cluster and rebind the application to the valkey cluster.
+
+## Cleanup
+
+```bash
+# remove service keys
+cf delete-service-key redis-cluster-test redis-cluster-key -f
+cf delete-service-key valkey-cluster-test valkey-cluster-key -f
+
+# remove old redis service
+cf ds redis-cluster-test -f
+```
+
+## Troubleshooting
+
+### Cluster State Fail / Nodes Not Discovering Each Other
+
+If `cluster info` shows `cluster_state:fail` and `cluster_known_nodes:1`,
+the cluster gossip protocol is not working.
+
+Check the `CLUSTER NODES` output for the bus port:
+
+```bash
+redis-cli -h $HOST -p $PORT -a "$PASS" CLUSTER NODES
+```
+
+If you see `:6379@26379` (bus port 26379), the cluster has TLS dual-mode
+enabled. The bus port is calculated as `tls-port + 10000` (16379 + 10000
+= 26379). Verify the bus port is reachable between nodes:
+
+```bash
+nc -zv <other-node-ip> 26379
+```
+
+If the `CLUSTER MEET` command in the post-deploy script uses port 6379,
+the cluster will try bus port 16379 (6379 + 10000) instead of 26379,
+causing nodes to never discover each other. The fix is to use the TLS
+port (16379) in the CLUSTER MEET command when TLS dual-mode is enabled.
+
+### Cluster Health Issues
+
+If `cluster info` shows `cluster_state:fail` but nodes are known, check
+slot assignment:
+
+```bash
+redis-cli -c -h $HOST -p $PORT -a "$PASS" CLUSTER NODES
+```
+
+All nodes should be visible and slots fully assigned (0-16383). If nodes
+are missing or slots are unassigned, the cluster needs to be repaired
+before migration can proceed.

--- a/docs/walkthroughs/valkey-standalone-migration.md
+++ b/docs/walkthroughs/valkey-standalone-migration.md
@@ -1,0 +1,188 @@
+# Migrating from Redis to Valkey Standalone
+
+This guide walks through migrating a Cloud Foundry application from a
+Blacksmith-managed Redis service instance to a Valkey standalone instance
+using live replication to achieve near-zero data loss.
+
+## Prerequisites
+
+- BOSH CLI access with permissions to SSH into deployments
+- CF CLI authenticated with space developer permissions
+- A running Redis service instance with data to migrate
+- A Valkey standalone service instance provisioned via Blacksmith
+
+## Test Application
+
+### App Location
+
+`~/ocfp/apps/apps/cf-redis-example-app`
+
+## Push Application
+
+```bash
+cf push redis-example-app
+```
+
+## Create Services
+
+```bash
+cf cs redis cache-small redis-test
+cf cs valkey standalone-8 valkeys8
+```
+
+## Bind to Redis
+
+```bash
+cf bs redis-example-app redis-test
+cf restage redis-example-app
+```
+
+## Export App Route
+
+```bash
+# use cf app redis-example-app to find the route and grep it out
+export APP=https://$(cf app redis-example-app | grep routes: | awk '{print $2}')
+
+# or manually set it to the route you see in the output of `cf app redis-example-app`
+export APP=https://redis-example-app.apps.aws.lab.fivetwenty.io
+```
+
+## Populate with Some Data
+
+```bash
+curl -X PUT $APP/foo -d 'data=bar'
+curl -X PUT $APP/hello -d 'data=world'
+curl -X PUT $APP/number -d 'data=42'
+curl -X PUT $APP/name -d 'data=redis'
+curl -X PUT $APP/language -d 'data=cloudfoundry'
+```
+
+## Retrieve Data Before Migration
+
+```bash
+curl -X GET $APP/foo
+curl -X GET $APP/hello
+curl -X GET $APP/number
+curl -X GET $APP/name
+curl -X GET $APP/language
+```
+
+
+## Create Service Key for Redis
+
+```bash
+cf create-service-key redis-test redis-test-key
+# retrieve the service key credentials
+cf service-key redis-test redis-test-key
+```
+
+## Get Valkey BOSH Deployment
+
+```bash
+export VALKEY_DEPLOYMENT=$(bosh deps | grep valkey-standalone-8 | awk '{print $1}')
+```
+
+## SSH to the Valkey Instance
+
+```bash
+bosh -d $VALKEY_DEPLOYMENT ssh
+```
+
+## Disable CONFIG Command Restriction
+
+```bash
+# identify the configuration file path and comment out the
+# `rename-command CONFIG ""` line to allow the CONFIG command
+export CONFIG_FILE=$(ps -ef | grep valkey | grep -v grep | head -n 1  | awk '{print $NF}')
+sed -i '/^rename-command CONFIG ""/s/^/#/' $CONFIG_FILE
+
+# restart valkey to apply the changes
+monit restart standalone-8
+```
+
+## Configure Replication
+
+```bash
+export REDIS_HOST=<redis-host-from-service-key>
+# use getent to get the ip of the redis host
+getent hosts $REDIS_HOST | awk '{print $1}'
+
+# enter the redis cli on the valkey instance using the password from the config file
+redis -p 6379 -a $(cat $CONFIG_FILE | grep requirepass | awk '{print $2}')
+```
+
+Configure valkey to replicate from redis. Replace `<redis-host>`, `<redis-port>`,
+and `<redis-password>` with the values from the redis service key credentials,
+using the getent output for the host ip.
+
+```redis-cli
+REPLICAOF <redis-host> <redis-port>
+CONFIG SET masterauth <redis-password>
+```
+
+Verify the data is being replicated to valkey:
+
+```redis-cli
+get foo
+get hello
+get number
+get name
+get language
+```
+
+
+## Switch Application to Valkey
+
+```bash
+cf bs redis-example-app valkeys8
+
+# unbind from redis
+cf us redis-example-app redis-test
+
+# stop the app so that no more writes are sent to the old master
+cf stop redis-example-app
+```
+
+## Promote Valkey to Master
+
+```redis-cli
+REPLICAOF NO ONE
+INFO replication
+exit
+```
+
+## Reinstate CONFIG Restriction and Restart
+
+```bash
+sed -i '/^#rename-command CONFIG ""/s/^#//' $CONFIG_FILE
+monit restart standalone-8
+```
+
+## Restage and Verify
+
+```bash
+cf restage redis-example-app
+
+# verify data is accessible via valkey
+curl -X GET $APP/foo
+curl -X GET $APP/hello
+curl -X GET $APP/number
+curl -X GET $APP/name
+curl -X GET $APP/language
+```
+
+## Cleanup Old Redis Service
+
+```bash
+cf delete-service-key redis-test redis-test-key -f
+cf ds redis-test -f
+```
+
+## Troubleshooting
+
+if on pushing data you receive 
+
+`<h1>Internal Server Error</h1>`
+
+* first make sure you have **restaged the app** after binding to the service. 
+* If you have restaged and are still receiving this error, check the logs for the app with `cf logs redis-example-app --recent` and look for any errors related to connecting to the Redis service.

--- a/hooks/addon-bosh~bo.pm
+++ b/hooks/addon-bosh~bo.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Blacksmith::BOSH v1.1.0;
+package Genesis::Hook::Addon::Blacksmith::BOSH v1.1.1;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-boss~b.pm
+++ b/hooks/addon-boss~b.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Blacksmith::Boss v1.1.0;
+package Genesis::Hook::Addon::Blacksmith::Boss v1.1.1;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-curl~cu.pm
+++ b/hooks/addon-curl~cu.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Blacksmith::Curl v1.1.0;
+package Genesis::Hook::Addon::Blacksmith::Curl v1.1.1;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-open~o.pm
+++ b/hooks/addon-open~o.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Blacksmith::Open v1.1.0;
+package Genesis::Hook::Addon::Blacksmith::Open v1.1.1;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-register~re.pm
+++ b/hooks/addon-register~re.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Blacksmith::Register v1.1.0;
+package Genesis::Hook::Addon::Blacksmith::Register v1.1.1;
 
 use v5.20;
 use warnings;

--- a/hooks/blueprint.pm
+++ b/hooks/blueprint.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Blueprint::Blacksmith v1.1.0;
+package Genesis::Hook::Blueprint::Blacksmith v1.1.1;
 
 use v5.20; # Genesis min perl version is 5.20
 use warnings;

--- a/hooks/blueprint.pm
+++ b/hooks/blueprint.pm
@@ -80,6 +80,7 @@ sub validate_blacksmith_features {
 		stackit
 		rabbitmq
 		redis
+		valkey
 		postgresql
 		mariadb
 		kubernetes
@@ -88,6 +89,8 @@ sub validate_blacksmith_features {
 		shield-agent
 		redis-tls
 		redis-dual-mode
+		valkey-tls
+		valkey-dual-mode
 		rabbitmq-tls
 		rabbitmq-dual-mode
 		rabbitmq-dashboard-registration
@@ -203,14 +206,14 @@ sub is_iaas_feature {
 # is_forge_feature - Check if feature is forge-related {{{2
 sub is_forge_feature {
 	my ($self, $feature) = @_;
-	return $feature =~ /^(rabbitmq|redis|postgresql|mariadb|kubernetes)$/;
+	return $feature =~ /^(rabbitmq|redis|valkey|postgresql|mariadb|kubernetes)$/;
 }
 # }}}
 
 # is_addon_feature - Check if feature is addon-related {{{2
 sub is_addon_feature {
 	my ($self, $feature) = @_;
-	return $feature =~ /^(broker-tls|shield-backups|shield-agent|redis-tls|redis-dual-mode|rabbitmq-tls|rabbitmq-dual-mode|rabbitmq-dashboard-registration|rabbitmq-autoscale|cf-route-registrar|cf-integration)$/;
+	return $feature =~ /^(broker-tls|shield-backups|shield-agent|redis-tls|redis-dual-mode|valkey-tls|valkey-dual-mode|rabbitmq-tls|rabbitmq-dual-mode|rabbitmq-dashboard-registration|rabbitmq-autoscale|cf-route-registrar|cf-integration)$/;
 }
 # }}}
 
@@ -273,6 +276,12 @@ sub process_addon_feature {
 	}
 	elsif ($feature eq 'redis-dual-mode') {
 		$self->add_files("manifests/forges/redis-dual-mode.yml");
+	}
+	elsif ($feature eq 'valkey-tls') {
+		$self->add_files("manifests/forges/valkey-tls.yml");
+	}
+	elsif ($feature eq 'valkey-dual-mode') {
+		$self->add_files("manifests/forges/valkey-dual-mode.yml");
 	}
 	elsif ($feature eq 'rabbitmq-tls') {
 		$self->add_files("manifests/forges/rabbitmq-tls.yml");
@@ -355,7 +364,7 @@ sub validate_configuration {
 
 	# Validate forge selection
 	if ($forge_count == 0) {
-		push @errors, "You have not activated any Blacksmith Forges. Please specify at least one of: rabbitmq, redis, postgresql, mariadb, kubernetes.";
+		push @errors, "You have not activated any Blacksmith Forges. Please specify at least one of: rabbitmq, redis, valkey, postgresql, mariadb, kubernetes.";
 	}
 
 	# Bail if we have errors

--- a/hooks/check.pm
+++ b/hooks/check.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Check::Blacksmith v1.1.0;
+package Genesis::Hook::Check::Blacksmith v1.1.1;
 
 use v5.20; # Genesis min perl version is 5.20
 use warnings;

--- a/hooks/check.pm
+++ b/hooks/check.pm
@@ -319,6 +319,9 @@ sub check_feature_compatibility {
 		push @errors, "redis-tls feature requires redis forge to be enabled";
 	}
 
+	if ($self->wants_feature('valkey-tls') && !$self->wants_feature('valkey')) {
+		push @errors, "valkey-tls feature requires valkey forge to be enabled";
+	}
 	if ($self->wants_feature('rabbitmq-tls') && !$self->wants_feature('rabbitmq')) {
 		push @errors, "rabbitmq-tls feature requires rabbitmq forge to be enabled";
 	}

--- a/hooks/cloud-config.pm
+++ b/hooks/cloud-config.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::CloudConfig::Blacksmith v1.1.0;
+package Genesis::Hook::CloudConfig::Blacksmith v1.1.1;
 
 use v5.20;
 use warnings; # Genesis min perl version is 5.20

--- a/hooks/features.pm
+++ b/hooks/features.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Features::Blacksmith v1.1.0;
+package Genesis::Hook::Features::Blacksmith v1.1.1;
 
 use v5.20;
 use warnings; # Genesis min perl version is 5.20

--- a/hooks/features.pm
+++ b/hooks/features.pm
@@ -34,6 +34,10 @@ sub perform {
         $self->add_feature('redis-tls');
       }
 
+      if ($self->has_feature('valkey')) {
+        $self->add_feature('valkey-tls');
+      }
+
       if ($self->has_feature('rabbitmq')) {
         $self->add_feature('rabbitmq-tls');
         $self->add_feature('rabbitmq-dashboard-registration');
@@ -47,6 +51,10 @@ sub perform {
 
     if ($feature eq 'redis-dual-mode') {
       $self->add_feature('redis-tls');
+    }
+
+    if ($feature eq 'valkey-dual-mode') {
+      $self->add_feature('valkey-tls');
     }
   }
 

--- a/hooks/info.pm
+++ b/hooks/info.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Info::Blacksmith v1.1.0;
+package Genesis::Hook::Info::Blacksmith v1.1.1;
 
 use v5.20; # Genesis min perl version is 5.20
 use warnings;

--- a/hooks/new.pm
+++ b/hooks/new.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::New::Blacksmith v1.1.0;
+package Genesis::Hook::New::Blacksmith v1.1.1;
 
 use strict;
 use warnings;

--- a/hooks/post-deploy.pm
+++ b/hooks/post-deploy.pm
@@ -74,6 +74,7 @@ sub display_deployment_summary {
   # Enabled forges
   my @forges;
   push @forges, 'Redis' if $self->want_feature('redis');
+  push @forges, 'Valkey' if $self->want_feature('valkey');
   push @forges, 'PostgreSQL' if $self->want_feature('postgresql');
   push @forges, 'RabbitMQ' if $self->want_feature('rabbitmq');
   push @forges, 'MariaDB' if $self->want_feature('mariadb');

--- a/hooks/post-deploy.pm
+++ b/hooks/post-deploy.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::PostDeploy::Blacksmith v1.1.0;
+package Genesis::Hook::PostDeploy::Blacksmith v1.1.1;
 
 use v5.20; # Genesis min perl version is 5.20
 use warnings;

--- a/hooks/pre-deploy.pm
+++ b/hooks/pre-deploy.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::PreDeploy::Blacksmith v1.1.0;
+package Genesis::Hook::PreDeploy::Blacksmith v1.1.1;
 
 use v5.20; # Genesis min perl version is 5.20
 use warnings;

--- a/kit.yml
+++ b/kit.yml
@@ -1,6 +1,6 @@
 ---
 name:    blacksmith
-version: 1.1.0
+version: 1.1.1
 author:  Blacksmith Community
 docs:     https://github.com/cloudfoundry-community/blacksmith-boshrelease
 code:     https://github.com/genesis-community/blacksmith-genesis-kit

--- a/manifests/forges/redis.yml
+++ b/manifests/forges/redis.yml
@@ -31,9 +31,9 @@ meta:
 
 releases:
 - name: redis-forge
-  version: 1.4.1
-  url: https://github.com/blacksmith-community/redis-forge-boshrelease/releases/download/v1.4.1/redis-forge-1.4.1.tgz
-  sha1: sha256:df23c176c40955c3173c45649066d5952ce62957aecd4361832892450171d412
+  version: 1.4.2
+  url: https://github.com/blacksmith-community/redis-forge-boshrelease/releases/download/v1.4.2/redis-forge-1.4.2.tgz
+  sha1: sha256:5005dd6499f27e999e2716a3bd2a3147a127e425d1ec48b8a3a2eb3adbfc4948
 
 params:
   releases:

--- a/manifests/forges/valkey-dual-mode.yml
+++ b/manifests/forges/valkey-dual-mode.yml
@@ -1,0 +1,9 @@
+instance_groups:
+- name: blacksmith
+  jobs:
+  - release: valkey-forge
+    name:    valkey-blacksmith-plans
+    properties:
+      valkey:
+        tls:
+          dual-mode: true

--- a/manifests/forges/valkey-tls.yml
+++ b/manifests/forges/valkey-tls.yml
@@ -1,0 +1,13 @@
+---
+instance_groups:
+- name: blacksmith
+  jobs:
+  - release: valkey-forge
+    name:    valkey-blacksmith-plans
+    properties:
+      valkey:
+        tls:
+          enabled: true
+          ca:      (( vault meta.vault "/tls/ca:combined" ))
+          ca_cert: (( vault meta.vault "/tls/ca:certificate" ))
+          ca_key:  (( vault meta.vault "/tls/ca:key" ))

--- a/manifests/forges/valkey.yml
+++ b/manifests/forges/valkey.yml
@@ -1,0 +1,82 @@
+---
+meta:
+  environment: (( grab genesis.env || params.env ))
+  bosh_env: (( grab genesis.bosh_env || params.bosh_env || params.env ))
+
+  default:
+    valkey_tags:
+    - blacksmith
+    - dedicated
+    - valkey
+
+    valkey_plans:
+      standalone-7:
+        name: standalone-7
+        description: A dedicated Valkey 7 server, with no redundancy or replication
+        limit: 7
+        type: standalone-7
+        vm_type: default
+      standalone-8:
+        name: standalone-8
+        description: A dedicated Valkey 8 server, with no redundancy or replication
+        limit: 7
+        type: standalone-8
+        vm_type: default
+      standalone-9:
+        name: standalone-9
+        description: A dedicated Valkey 9 server, with no redundancy or replication
+        limit: 7
+        type: standalone-9
+        vm_type: default
+      cluster-7:
+        name: cluster-7
+        description: A Valkey 7 cluster with 3 master nodes and 3 replica nodes
+        limit: 5
+        type: cluster-7
+        vm_type: default
+        masters: 3
+        replicas: 1
+      cluster-8:
+        name: cluster-8
+        description: A Valkey 8 cluster with 3 master nodes and 3 replica nodes
+        limit: 5
+        type: cluster-8
+        vm_type: default
+        masters: 3
+        replicas: 1
+      cluster-9:
+        name: cluster-9
+        description: A Valkey 9 cluster with 3 master nodes and 3 replica nodes
+        limit: 5
+        type: cluster-9
+        vm_type: default
+        masters: 3
+        replicas: 1
+
+releases:
+- name: valkey-forge
+  version: 0+dev.5
+
+
+params:
+  releases:
+  - (( append ))
+  - (( grab releases.valkey-forge ))
+
+instance_groups:
+- name: blacksmith
+  jobs:
+  - release: valkey-forge
+    name:    valkey-blacksmith-plans
+    properties:
+      environment: (( grab meta.environment ))
+      bosh_env: (( grab meta.bosh_env ))
+
+      plans: (( grab params.valkey_plans || meta.default.valkey_plans ))
+      service:
+        id:          (( grab params.valkey_service_id          || "valkey" ))
+        name:        (( grab params.valkey_service_name        || params.valkey_service_id || "valkey" ))
+        description: (( grab params.valkey_service_description || "A dedicated Valkey instance, deployed on-demand" ))
+        tags:        (( grab params.valkey_service_tags        || meta.default.valkey_tags ))
+        limit:       (( grab params.valkey_service_limit       || 0 ))
+        type:        (( grab params.valkey_service_type        || "standalone-9" ))

--- a/manifests/forges/valkey.yml
+++ b/manifests/forges/valkey.yml
@@ -55,9 +55,10 @@ meta:
         replicas: 1
 
 releases:
-- name: valkey-forge
-  version: 0+dev.5
-
+ - name: valkey-forge
+   version: 1.0.1
+   url: https://github.com/blacksmith-community/valkey-forge-boshrelease/releases/download/v1.0.1/valkey-forge-1.0.1.tar.gz
+   sha1: sha256:f501b918934ad7e16daaa47d5b30415162dcdfa1b3b23474faa4b8d4718f898c
 
 params:
   releases:

--- a/manifests/forges/valkey.yml
+++ b/manifests/forges/valkey.yml
@@ -8,6 +8,7 @@ meta:
     - blacksmith
     - dedicated
     - valkey
+    - redis
 
     valkey_plans:
       standalone-7:

--- a/manifests/releases/blacksmith.yml
+++ b/manifests/releases/blacksmith.yml
@@ -2,9 +2,9 @@
 releases:
 releases:
 - name:    blacksmith
-  version: 2.0.15
-  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v2.0.15/blacksmith-2.0.15.tgz
-  sha1:    sha256:060cf101fe904f583fb613423e343b4e37e4a78a5255fe47e15d1c7326fb2da3
+  version: 2.1.1
+  url:     https://github.com/blacksmith-community/blacksmith-boshrelease/releases/download/v2.1.1/blacksmith-2.1.1.tgz
+  sha1:    sha256:5390931e47f652e5af548f99a0ecf0dcdb13c61bad62e35eb41e090c0d2e18ab
 
 - name:    bosh
   version: "282.0.7"


### PR DESCRIPTION
## Summary

- Add Valkey standalone, TLS, and dual-mode forge definitions
- Update deploy hooks for Valkey service provisioning
- Add Valkey BOSH release reference
- Include migration walkthroughs for standalone (live replication) and cluster (RedisShake)
- Update documentation with Valkey service references

## Migration Guides

Two walkthroughs are included for operators migrating existing Redis services:

- **Standalone**: Uses `REPLICAOF` for live replication with near-zero data loss
- **Cluster**: Uses RedisShake for cluster-to-cluster data sync